### PR TITLE
Fix problems with Terraform 0.13+ and usage of variables

### DIFF
--- a/aws/terraform_provider.go
+++ b/aws/terraform_provider.go
@@ -6,11 +6,14 @@ import (
 	"github.com/cycloidio/terracost/terraform"
 )
 
+// RegistryName is the fully qualified name under which this provider is stored in the registry.
+const RegistryName = "registry.terraform.io/hashicorp/aws"
+
 // TerraformProviderInitializer is a terraform.ProviderInitializer that initializes the default AWS provider.
 var TerraformProviderInitializer = terraform.ProviderInitializer{
-	MatchNames: []string{ProviderName},
-	Provider: func(config terraform.ProviderConfig) (terraform.Provider, error) {
-		regCode := region.Code(config.Expressions["region"].ConstantValue)
+	MatchNames: []string{ProviderName, RegistryName},
+	Provider: func(values map[string]string) (terraform.Provider, error) {
+		regCode := region.Code(values["region"])
 		return awstf.NewProvider(ProviderName, regCode)
 	},
 }

--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 var terraformProviderInitializer = terraform.ProviderInitializer{
-	MatchNames: []string{"aws-test"},
-	Provider: func(config terraform.ProviderConfig) (terraform.Provider, error) {
-		regCode := region.Code(config.Expressions["region"].ConstantValue)
+	MatchNames: []string{"aws", "aws-test"},
+	Provider: func(config map[string]string) (terraform.Provider, error) {
+		regCode := region.Code(config["region"])
 		return awstf.NewProvider("aws-test", regCode)
 	},
 }

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -22,8 +22,8 @@ func TestPlan_ExtractPlannedQueries(t *testing.T) {
 		provider := mock.NewTerraformProvider(ctrl)
 
 		plan := terraform.NewPlan(terraform.ProviderInitializer{
-			MatchNames: []string{"aws-test"},
-			Provider: func(_ terraform.ProviderConfig) (terraform.Provider, error) {
+			MatchNames: []string{"aws", "aws-test"},
+			Provider: func(_ map[string]string) (terraform.Provider, error) {
 				return provider, nil
 			},
 		})
@@ -51,8 +51,8 @@ func TestPlan_ExtractPlannedQueries(t *testing.T) {
 		defer ctrl.Finish()
 
 		plan := terraform.NewPlan(terraform.ProviderInitializer{
-			MatchNames: []string{"aws-test"},
-			Provider: func(_ terraform.ProviderConfig) (terraform.Provider, error) {
+			MatchNames: []string{"aws", "aws-test"},
+			Provider: func(_ map[string]string) (terraform.Provider, error) {
 				return nil, errors.New("bad provider")
 			},
 		})
@@ -75,8 +75,8 @@ func TestPlan_ExtractPlannedQueries(t *testing.T) {
 		provider := mock.NewTerraformProvider(ctrl)
 
 		plan := terraform.NewPlan(terraform.ProviderInitializer{
-			MatchNames: []string{"aws-test"},
-			Provider: func(_ terraform.ProviderConfig) (terraform.Provider, error) {
+			MatchNames: []string{"aws", "aws-test"},
+			Provider: func(_ map[string]string) (terraform.Provider, error) {
 				return provider, nil
 			},
 		})
@@ -106,8 +106,8 @@ func TestPlan_ExtractPriorQueries(t *testing.T) {
 		provider := mock.NewTerraformProvider(ctrl)
 
 		plan := terraform.NewPlan(terraform.ProviderInitializer{
-			MatchNames: []string{"aws-test"},
-			Provider: func(_ terraform.ProviderConfig) (terraform.Provider, error) {
+			MatchNames: []string{"aws", "aws-test"},
+			Provider: func(_ map[string]string) (terraform.Provider, error) {
 				return provider, nil
 			},
 		})
@@ -135,8 +135,8 @@ func TestPlan_ExtractPriorQueries(t *testing.T) {
 		defer ctrl.Finish()
 
 		plan := terraform.NewPlan(terraform.ProviderInitializer{
-			MatchNames: []string{"aws-test"},
-			Provider: func(_ terraform.ProviderConfig) (terraform.Provider, error) {
+			MatchNames: []string{"aws", "aws-test"},
+			Provider: func(_ map[string]string) (terraform.Provider, error) {
 				return nil, errors.New("bad provider")
 			},
 		})
@@ -159,8 +159,8 @@ func TestPlan_ExtractPriorQueries(t *testing.T) {
 		provider := mock.NewTerraformProvider(ctrl)
 
 		plan := terraform.NewPlan(terraform.ProviderInitializer{
-			MatchNames: []string{"aws-test"},
-			Provider: func(_ terraform.ProviderConfig) (terraform.Provider, error) {
+			MatchNames: []string{"aws", "aws-test"},
+			Provider: func(_ map[string]string) (terraform.Provider, error) {
 				return provider, nil
 			},
 		})

--- a/terraform/provider.go
+++ b/terraform/provider.go
@@ -20,6 +20,6 @@ type ProviderInitializer struct {
 	// implementation (such as `google` and `google-beta`).
 	MatchNames []string
 
-	// Provider initializes a Provider instance given the ProviderConfig and returns it.
-	Provider func(config ProviderConfig) (Provider, error)
+	// Provider initializes a Provider instance given the values defined in the config and returns it.
+	Provider func(values map[string]string) (Provider, error)
 }

--- a/terraform/schema.go
+++ b/terraform/schema.go
@@ -2,12 +2,14 @@ package terraform
 
 // ProviderConfigExpression is a single configuration variable of a ProviderConfig.
 type ProviderConfigExpression struct {
-	ConstantValue string `json:"constant_value"`
+	ConstantValue string   `json:"constant_value"`
+	References    []string `json:"references"`
 }
 
 // ProviderConfig is configuration of a provider with the given Name.
 type ProviderConfig struct {
 	Name        string                              `json:"name"`
+	Alias       string                              `json:"alias"`
 	Expressions map[string]ProviderConfigExpression `json:"expressions"`
 }
 
@@ -34,4 +36,9 @@ type Module struct {
 // Configuration is a Terraform plan configuration.
 type Configuration struct {
 	ProviderConfig map[string]ProviderConfig `json:"provider_config"`
+}
+
+// Variable is a Terraform variable declaration.
+type Variable struct {
+	Value string `json:"value"`
 }


### PR DESCRIPTION
## Abstract

This PR solves two problems:

1. Terraform 0.13 changed the value of `provider_name` field in a resource spec: it is now a fully qualified URI (`registry.terraform.io/hashicorp/aws`) instead of being just a provider name (`aws`). This requires the fully qualified name (`RegistryName`) to be added to the `MatchNames` list of AWS `ProviderInitializer` as well as a change to how plans are read. This closes #18. Note: after the change, multiple aliases for a provider will not work, this will be fixed in a separate issue.
2. Referencing variables in provider config would not work as variables were unsupported. This PR adds support for using variables in provider config and closes #19.