### PR TITLE
aws: add WithIngestionFilter option and implement MinimalFilter

### DIFF
--- a/aws/filter.go
+++ b/aws/filter.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"github.com/cycloidio/terracost/price"
+)
+
+// IngestionFilter allows control over what pricing data is ingested. Given a price.WithProduct the function returns
+// true if the record should be ingested, false if it should be skipped.
+type IngestionFilter func(pp *price.WithProduct) bool
+
+// DefaultFilter ingests all the records without filtering.
+func DefaultFilter(_ *price.WithProduct) bool {
+	return true
+}
+
+// MinimalFilter only ingests the supported records, skipping those that would never be used.
+func MinimalFilter(pp *price.WithProduct) bool {
+	switch pp.Product.Service {
+	case "AmazonEC2":
+		return minimalFilterEC2(pp)
+	case "AmazonRDS":
+		return minimalFilterRDS(pp)
+	default:
+		return false
+	}
+}
+
+// minimalFilterEC2 only ingests storage-related records as well as compute records that match supported attributes.
+func minimalFilterEC2(pp *price.WithProduct) bool {
+	switch pp.Product.Family {
+	case "Compute Instance":
+		allowedProductAttrs := map[string][]string{
+			"capacitystatus":  {"Used"},
+			"operatingSystem": {"Linux"},
+			"preInstalledSw":  {"NA"},
+			"tenancy":         {"Shared", "Dedicated"},
+		}
+		for k, vals := range allowedProductAttrs {
+			if !isValueAllowed(pp.Product.Attributes[k], vals) {
+				return false
+			}
+		}
+		return true
+	case "Storage", "System Operation":
+		return true
+	default:
+		return false
+	}
+}
+
+// minimalFilterRDS only ingests RDS records of supported product families.
+func minimalFilterRDS(pp *price.WithProduct) bool {
+	switch pp.Product.Family {
+	case "Database Instance", "Database Storage", "Provisioned IOPS":
+		return true
+	default:
+		return false
+	}
+}
+
+// isValueAllowed returns true if the allowed slice contains the value.
+func isValueAllowed(value string, allowed []string) bool {
+	for _, v := range allowed {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}

--- a/aws/filter_test.go
+++ b/aws/filter_test.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cycloidio/terracost/price"
+	"github.com/cycloidio/terracost/product"
+)
+
+func TestMinimalFilter(t *testing.T) {
+	t.Run("Allowed", func(t *testing.T) {
+		pps := []*price.WithProduct{
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Storage"}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "System Operation"}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance", Attributes: map[string]string{
+				"capacitystatus":  "Used",
+				"operatingSystem": "Linux",
+				"preInstalledSw":  "NA",
+				"tenancy":         "Shared",
+			}}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance", Attributes: map[string]string{
+				"capacitystatus":  "Used",
+				"operatingSystem": "Linux",
+				"preInstalledSw":  "NA",
+				"tenancy":         "Dedicated",
+			}}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "Database Instance"}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "Database Storage"}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "Provisioned IOPS"}},
+		}
+
+		for i, pp := range pps {
+			assert.True(t, MinimalFilter(pp), "case %d", i)
+		}
+	})
+
+	t.Run("Skipped", func(t *testing.T) {
+		pps := []*price.WithProduct{
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance (bare metal)"}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "NAT Gateway"}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Fee"}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance", Attributes: map[string]string{
+				"capacitystatus":  "Used",
+				"operatingSystem": "Linux",
+				"preInstalledSw":  "NA",
+				"tenancy":         "Host",
+			}}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance", Attributes: map[string]string{
+				"capacitystatus":  "Used",
+				"operatingSystem": "SUSE",
+				"preInstalledSw":  "NA",
+				"tenancy":         "Shared",
+			}}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance", Attributes: map[string]string{
+				"capacitystatus":  "Used",
+				"operatingSystem": "Linux",
+				"preInstalledSw":  "SQL Server",
+				"tenancy":         "Shared",
+			}}},
+			{Product: &product.Product{Service: "AmazonEC2", Family: "Compute Instance", Attributes: map[string]string{
+				"capacitystatus":  "AllocatedCapacityReservation",
+				"operatingSystem": "Linux",
+				"preInstalledSw":  "NA",
+				"tenancy":         "Shared",
+			}}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "CPU Credits"}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "Performance Insights"}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "RDSProxy"}},
+			{Product: &product.Product{Service: "AmazonRDS", Family: "Serverless"}},
+		}
+
+		for i, pp := range pps {
+			assert.False(t, MinimalFilter(pp), "case %d", i)
+		}
+	})
+}

--- a/aws/options.go
+++ b/aws/options.go
@@ -45,3 +45,10 @@ func WithProgress(progressCh chan<- progress.Progress, interval time.Duration) O
 		ing.progressInterval = interval
 	}
 }
+
+// WithIngestionFilter sets a custom IngestionFilter to control which pricing data records should be ingested.
+func WithIngestionFilter(filter IngestionFilter) Option {
+	return func(ing *Ingester) {
+		ing.ingestionFilter = filter
+	}
+}


### PR DESCRIPTION
WithIngestionFilter option can be used to control the data that is ingested into the database. By using MinimalFilter, only the minimal amount of data is ingested, saving time and storage space.

This PR closes #22.