### PR TITLE
Include a DB Docker container and a Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,20 @@ $ git fetch upstream --prune
 $ git rebase upstream/master
 ```
 
+### Test your submission
+
+First-time setup of the development environment requires running the database migrations:
+
+```shell
+$ make db-migrate
+```
+
+Run all the tests:
+
+```shell
+$ make test
+```
+
 ## Adding a new resource
 
 ### AWS

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+IS_CI ?= 0
+
+DOCKER_COMPOSE_CMD := docker-compose
+GO_CMD := go
+GO_TEST_CMD := $(GO_CMD) test ./...
+GO_RUN_CMD := $(GO_CMD) run
+
+.PHONY: test
+test: db-up
+	@$(GO_TEST_CMD)
+
+.PHONY: db-up
+db-up: # Start the DB server
+ifeq ($(IS_CI), 0)
+	@$(DOCKER_COMPOSE_CMD) up -d database
+endif
+
+.PHONY: down
+down:
+	@$(DOCKER_COMPOSE_CMD) down
+
+.PHONY: db-migrate
+db-migrate: db-up
+	@$(GO_RUN_CMD) scripts/migrate.go
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  database:
+    image: mysql:8.0.21
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - '33060:3306'
+    environment:
+      - MYSQL_ROOT_PASSWORD=terracost
+      - MYSQL_DATABASE=terracost_test

--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -33,7 +33,7 @@ func TestAWSEstimation(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db, err := sql.Open("mysql", "root:youdeploy@tcp(localhost:3306)/youdeploy_public_test?multiStatements=true")
+	db, err := sql.Open("mysql", "root:terracost@tcp(localhost:33060)/terracost_test?multiStatements=true")
 	require.NoError(t, err)
 
 	backend := mysql.NewBackend(db)

--- a/e2e/aws_ingestion_test.go
+++ b/e2e/aws_ingestion_test.go
@@ -31,7 +31,7 @@ func TestAWSIngestion(t *testing.T) {
 
 	httpClient := mock.NewHTTPClient(ctrl)
 
-	db, err := sql.Open("mysql", "root:youdeploy@tcp(localhost:3306)/youdeploy_public_test?multiStatements=true")
+	db, err := sql.Open("mysql", "root:terracost@tcp(localhost:33060)/terracost_test?multiStatements=true")
 	require.NoError(t, err)
 
 	f, err := os.Open("testdata/AmazonEC2_eu-west-3.csv")

--- a/ingestion.go
+++ b/ingestion.go
@@ -2,6 +2,7 @@ package terracost
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cycloidio/terracost/price"
 	"github.com/cycloidio/terracost/product"
@@ -40,18 +41,18 @@ func IngestPricing(ctx context.Context, backend Backend, ingester Ingester) erro
 			var err error
 			pp.Product.ID, err = backend.Product().Upsert(ctx, pp.Product)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to upsert product (SKU=%q): %w", pp.Product.SKU, err)
 			}
 			skuProductID[pp.Product.SKU] = pp.Product.ID
 		}
 
 		if _, err := backend.Price().Upsert(ctx, pp); err != nil {
-			return err
+			return fmt.Errorf("failed to upsert price (SKU=%q): %w", pp.Product.SKU, err)
 		}
 	}
 
 	if err := ingester.Err(); err != nil {
-		return err
+		return fmt.Errorf("unexpected ingester error: %w", err)
 	}
 	return nil
 }

--- a/scripts/migrate.go
+++ b/scripts/migrate.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/cycloidio/terracost/mysql"
+)
+
+func main() {
+	db, err := sql.Open("mysql", "root:terracost@tcp(localhost:33060)/terracost_test?multiStatements=true")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := mysql.Migrate(context.Background(), db, "_migrations"); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Migrated successfully!")
+}


### PR DESCRIPTION
## Abstract

This PR improves end-to-end testing by including a `docker-compose.yml` file and a `Makefile` to easily spin up a local environment.

## Metadata

Related: #21 