### PR TITLE
cost: store the errors instead of failing

### DIFF
--- a/cost/component.go
+++ b/cost/component.go
@@ -11,6 +11,8 @@ type Component struct {
 	Unit     string
 	Rate     decimal.Decimal
 	Details  []string
+
+	Error error
 }
 
 // Cost returns the cost of this component (Rate multiplied by Quantity).
@@ -37,4 +39,9 @@ func (cd ComponentDiff) PlannedCost() decimal.Decimal {
 		return decimal.Zero
 	}
 	return cd.Planned.Cost()
+}
+
+// Valid returns true if there are no errors in both the Planned and Prior components.
+func (cd ComponentDiff) Valid() bool {
+	return !((cd.Prior != nil && cd.Prior.Error != nil) || (cd.Planned != nil && cd.Planned.Error != nil))
 }

--- a/cost/component_test.go
+++ b/cost/component_test.go
@@ -1,6 +1,7 @@
 package cost_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -35,4 +36,27 @@ func TestComponentDiff_PlannedCost(t *testing.T) {
 		actual := cd.PlannedCost()
 		assert.True(t, actual.Equal(decimal.NewFromFloat(7.5)))
 	})
+}
+
+func TestComponentDiff_Valid(t *testing.T) {
+	err := fmt.Errorf("test error")
+	testcases := []struct {
+		prior, planned *cost.Component
+		valid          bool
+	}{
+		{&cost.Component{}, &cost.Component{}, true},
+		{&cost.Component{}, nil, true},
+		{nil, &cost.Component{}, true},
+		{&cost.Component{Error: err}, &cost.Component{}, false},
+		{&cost.Component{}, &cost.Component{Error: err}, false},
+		{&cost.Component{Error: err}, &cost.Component{Error: err}, false},
+		{&cost.Component{Error: err}, nil, false},
+		{nil, &cost.Component{Error: err}, false},
+		{nil, nil, true},
+	}
+
+	for i, tc := range testcases {
+		cd := cost.ComponentDiff{Prior: tc.prior, Planned: tc.planned}
+		assert.Equal(t, tc.valid, cd.Valid(), "case %d", i)
+	}
 }

--- a/cost/resource.go
+++ b/cost/resource.go
@@ -43,3 +43,26 @@ func (rd ResourceDiff) PlannedCost() decimal.Decimal {
 	}
 	return total
 }
+
+// Errors returns a map of Component errors keyed by the Component label.
+func (rd ResourceDiff) Errors() map[string]error {
+	errs := make(map[string]error)
+	for label, cd := range rd.ComponentDiffs {
+		if cd.Prior != nil && cd.Prior.Error != nil {
+			errs[label] = cd.Prior.Error
+		} else if cd.Planned != nil && cd.Planned.Error != nil {
+			errs[label] = cd.Planned.Error
+		}
+	}
+	return errs
+}
+
+// Valid returns true if there are no errors in all of the ResourceDiff's components.
+func (rd ResourceDiff) Valid() bool {
+	for _, cd := range rd.ComponentDiffs {
+		if (cd.Prior != nil && cd.Prior.Error != nil) || (cd.Planned != nil && cd.Planned.Error != nil) {
+			return false
+		}
+	}
+	return true
+}

--- a/cost/resource_test.go
+++ b/cost/resource_test.go
@@ -1,0 +1,105 @@
+package cost_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cycloidio/terracost/cost"
+)
+
+func TestResourceDiff_Errors(t *testing.T) {
+	rd := &cost.ResourceDiff{
+		Address: "complex_resource.example",
+		ComponentDiffs: map[string]*cost.ComponentDiff{
+			"BothNil": {
+				Prior:   nil,
+				Planned: nil,
+			},
+			"BothCorrect": {
+				Prior:   &cost.Component{},
+				Planned: &cost.Component{},
+			},
+			"BrokenPrior": {
+				Prior:   &cost.Component{Error: cost.ErrProductNotFound},
+				Planned: nil,
+			},
+			"BrokenPlanned": {
+				Prior:   nil,
+				Planned: &cost.Component{Error: cost.ErrPriceNotFound},
+			},
+			"BothBroken": {
+				Prior:   &cost.Component{Error: cost.ErrProductNotFound},
+				Planned: &cost.Component{Error: cost.ErrPriceNotFound},
+			},
+		},
+	}
+
+	expected := map[string]error{
+		"BrokenPrior":   cost.ErrProductNotFound,
+		"BrokenPlanned": cost.ErrPriceNotFound,
+		"BothBroken":    cost.ErrProductNotFound,
+	}
+	assert.Equal(t, expected, rd.Errors())
+}
+
+func TestResourceDiff_Valid(t *testing.T) {
+	testcases := []struct {
+		label string
+		cd    *cost.ComponentDiff
+		valid bool
+	}{
+		{
+			"BothNil",
+			&cost.ComponentDiff{
+				Prior:   nil,
+				Planned: nil,
+			},
+			true,
+		},
+		{
+			"BothCorrect",
+			&cost.ComponentDiff{
+				Prior:   &cost.Component{},
+				Planned: &cost.Component{},
+			},
+			true,
+		},
+		{
+			"BrokenPrior",
+			&cost.ComponentDiff{
+				Prior:   &cost.Component{Error: cost.ErrProductNotFound},
+				Planned: nil,
+			},
+			false,
+		},
+		{
+			"BrokenPlanned",
+			&cost.ComponentDiff{
+				Prior:   nil,
+				Planned: &cost.Component{Error: cost.ErrPriceNotFound},
+			},
+			false,
+		},
+		{
+			"BothBroken",
+			&cost.ComponentDiff{
+				Prior:   &cost.Component{Error: cost.ErrProductNotFound},
+				Planned: &cost.Component{Error: cost.ErrPriceNotFound},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			rd := &cost.ResourceDiff{
+				Address: tc.label,
+				ComponentDiffs: map[string]*cost.ComponentDiff{
+					tc.label: tc.cd,
+				},
+			}
+			assert.Equal(t, tc.valid, rd.Valid())
+		})
+	}
+}

--- a/cost/state_test.go
+++ b/cost/state_test.go
@@ -87,8 +87,9 @@ func TestNewState(t *testing.T) {
 
 		productRepo.EXPECT().Filter(ctx, queries[0].Components[0].ProductFilter).Return(nil, errors.New("repo fail"))
 
-		_, err := cost.NewState(ctx, backend, queries)
-		assert.Error(t, err)
+		state, err := cost.NewState(ctx, backend, queries)
+		require.NoError(t, err)
+		assert.Error(t, state.Resources["aws_instance.test1"].Components["Compute"].Error)
 	})
 
 	t.Run("PriceRepositoryFailure", func(t *testing.T) {
@@ -106,8 +107,9 @@ func TestNewState(t *testing.T) {
 		productRepo.EXPECT().Filter(ctx, queries[0].Components[0].ProductFilter).Return([]*product.Product{prod1}, nil)
 		priceRepo.EXPECT().Filter(ctx, prod1.ID, queries[0].Components[0].PriceFilter).Return(nil, errors.New("repo fail"))
 
-		_, err := cost.NewState(ctx, backend, queries)
-		assert.Error(t, err)
+		state, err := cost.NewState(ctx, backend, queries)
+		require.NoError(t, err)
+		assert.Error(t, state.Resources["aws_instance.test1"].Components["Compute"].Error)
 	})
 }
 


### PR DESCRIPTION
## Abstract

Whenever a `cost.State` is created using `cost.NewState` function, the previous behaviour was to fail it the first time an error is encountered (e.g. when no product matching the query was found.)

This PR adds a new field on `Component` to store the error. It is used by `cost.NewState` instead of returning the error from the function. The errors can then be read from a `ResourceDiff` by using the `Errors` method.

Closes #17 