### PR TITLE
estimation: expose a list of skipped resources

### DIFF
--- a/cost/resource.go
+++ b/cost/resource.go
@@ -8,6 +8,7 @@ import (
 // by the label.
 type Resource struct {
 	Components map[string]Component
+	Skipped    bool
 }
 
 // Cost returns the sum of costs of every Component of this Resource.

--- a/cost/state.go
+++ b/cost/state.go
@@ -40,6 +40,11 @@ func NewState(ctx context.Context, backend Backend, queries []query.Resource) (*
 	state := &State{Resources: make(map[string]Resource)}
 
 	for _, res := range queries {
+		// Mark the Resource as skipped if there are no valid Components.
+		if len(res.Components) == 0 {
+			state.Resources[res.Address] = Resource{Skipped: true}
+		}
+
 		for _, comp := range res.Components {
 			prods, err := backend.Product().Filter(ctx, comp.ProductFilter)
 			if err != nil {

--- a/cost/state_test.go
+++ b/cost/state_test.go
@@ -38,6 +38,10 @@ func TestNewState(t *testing.T) {
 				},
 			},
 		},
+		{
+			Address:    "aws_invalid_resource.skipped",
+			Components: nil,
+		},
 	}
 
 	t.Run("Success", func(t *testing.T) {
@@ -65,6 +69,9 @@ func TestNewState(t *testing.T) {
 							Quantity: decimal.NewFromInt(1),
 						},
 					},
+				},
+				"aws_invalid_resource.skipped": {
+					Skipped: true,
 				},
 			},
 		}

--- a/query/query.go
+++ b/query/query.go
@@ -13,7 +13,8 @@ type Resource struct {
 	// Address uniquely identifies this cloud Resource.
 	Address string
 
-	// Components is a list of price components that make up this Resource.
+	// Components is a list of price components that make up this Resource. If it is empty, the resource
+	// is considered to be skipped.
 	Components []Component
 }
 

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -92,6 +92,10 @@ func (p *Plan) extractQueries(modules map[string]Module, providers map[string]Pr
 	result := make([]query.Resource, 0)
 	for _, module := range modules {
 		for _, tfres := range module.Resources {
+			if tfres.Mode != "managed" {
+				continue
+			}
+
 			providerKey, ok := resToProvKey[tfres.Address]
 			if !ok {
 				providerKey = tfres.ProviderName
@@ -99,13 +103,11 @@ func (p *Plan) extractQueries(modules map[string]Module, providers map[string]Pr
 
 			if provider, ok := providers[providerKey]; ok {
 				comps := provider.ResourceComponents(tfres)
-				if comps != nil {
-					q := query.Resource{
-						Address:    tfres.Address,
-						Components: comps,
-					}
-					result = append(result, q)
+				q := query.Resource{
+					Address:    tfres.Address,
+					Components: comps,
 				}
+				result = append(result, q)
 			}
 		}
 	}

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -99,7 +99,8 @@ func TestPlan_ExtractPlannedQueries(t *testing.T) {
 
 		queries, err := plan.ExtractPlannedQueries()
 		require.NoError(t, err)
-		require.Len(t, queries, 0)
+		require.Len(t, queries, 2)
+		assert.Contains(t, queries, query.Resource{Address: "aws_instance.example"})
 	})
 }
 
@@ -183,6 +184,7 @@ func TestPlan_ExtractPriorQueries(t *testing.T) {
 
 		queries, err := plan.ExtractPriorQueries()
 		require.NoError(t, err)
-		require.Len(t, queries, 0)
+		require.Len(t, queries, 1)
+		assert.Contains(t, queries, query.Resource{Address: "aws_instance.example"})
 	})
 }

--- a/terraform/schema.go
+++ b/terraform/schema.go
@@ -22,6 +22,7 @@ type State struct {
 type Resource struct {
 	Address      string                 `json:"address"`
 	Index        int                    `json:"index"`
+	Mode         string                 `json:"mode"`
 	Type         string                 `json:"type"`
 	Name         string                 `json:"name"`
 	ProviderName string                 `json:"provider_name"`


### PR DESCRIPTION
This PR adds a new `Skipped` field to `cost.Resource`, as well as a new `SkippedAddresses` method to `cost.Plan` that returns a list of resource addresses that were skipped in the estimation process. Closes #12 