### PR TITLE
terraform: add child module support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support for child modules in Terraform plan files
+  ([Issue #37](https://github.com/cycloidio/terracost/issues/37))

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -37,7 +37,7 @@ func TestPlan_ExtractPlannedQueries(t *testing.T) {
 
 		provider.EXPECT().ResourceComponents(gomock.Any()).DoAndReturn(func(res terraform.Resource) ([]query.Component, error) {
 			if res.Type == "aws_instance" {
-				assert.Equal(t, "aws_instance.example", res.Address)
+				assert.Equal(t, "module.instance.aws_instance.example", res.Address)
 				assert.Equal(t, "t2.xlarge", res.Values["instance_type"])
 			} else {
 				assert.Equal(t, "aws_lb.example", res.Address)
@@ -100,7 +100,7 @@ func TestPlan_ExtractPlannedQueries(t *testing.T) {
 		queries, err := plan.ExtractPlannedQueries()
 		require.NoError(t, err)
 		require.Len(t, queries, 2)
-		assert.Contains(t, queries, query.Resource{Address: "aws_instance.example"})
+		assert.Contains(t, queries, query.Resource{Address: "module.instance.aws_instance.example"})
 	})
 }
 
@@ -126,7 +126,7 @@ func TestPlan_ExtractPriorQueries(t *testing.T) {
 		require.NoError(t, err)
 
 		provider.EXPECT().ResourceComponents(gomock.Any()).DoAndReturn(func(res terraform.Resource) ([]query.Component, error) {
-			assert.Equal(t, "aws_instance.example", res.Address)
+			assert.Equal(t, "module.instance.aws_instance.example", res.Address)
 			assert.Equal(t, "t2.micro", res.Values["instance_type"])
 			return []query.Component{}, nil
 		})
@@ -185,6 +185,6 @@ func TestPlan_ExtractPriorQueries(t *testing.T) {
 		queries, err := plan.ExtractPriorQueries()
 		require.NoError(t, err)
 		require.Len(t, queries, 1)
-		assert.Contains(t, queries, query.Resource{Address: "aws_instance.example"})
+		assert.Contains(t, queries, query.Resource{Address: "module.instance.aws_instance.example"})
 	})
 }

--- a/terraform/schema.go
+++ b/terraform/schema.go
@@ -13,9 +13,14 @@ type ProviderConfig struct {
 	Expressions map[string]ProviderConfigExpression `json:"expressions"`
 }
 
+// Values is a tree of modules and resources within.
+type Values struct {
+	RootModule Module `json:"root_module"`
+}
+
 // State is a collection of resource modules.
 type State struct {
-	Values map[string]Module `json:"values"`
+	Values Values `json:"values"`
 }
 
 // Resource is a single Terraform resource definition.
@@ -31,7 +36,9 @@ type Resource struct {
 
 // Module is a collection of resources.
 type Module struct {
-	Resources []Resource `json:"resources"`
+	Address      string     `json:"address"`
+	Resources    []Resource `json:"resources"`
+	ChildModules []*Module  `json:"child_modules"`
 }
 
 // Configuration is a Terraform plan configuration.
@@ -47,7 +54,10 @@ type Variable struct {
 
 // ConfigurationModule is used to configure a module.
 type ConfigurationModule struct {
-	Resources []ConfigurationResource `json:"resources"`
+	Resources   []ConfigurationResource `json:"resources"`
+	ModuleCalls map[string]struct {
+		Module *ConfigurationModule `json:"module"`
+	} `json:"module_calls"`
 }
 
 // ConfigurationResource is used to configure a single reosurce.

--- a/testdata/terraform-plan.json
+++ b/testdata/terraform-plan.json
@@ -3,28 +3,35 @@
   "terraform_version": "0.14.9",
   "planned_values": {
     "root_module": {
-      "resources": [
+      "child_modules": [
         {
-          "address": "aws_instance.example",
-          "mode": "managed",
-          "type": "aws_instance",
-          "name": "example",
-          "provider_name": "registry.terraform.io/hashicorp/aws",
-          "schema_version": 1,
-          "values": {
-            "ami": "ami-2757f631",
-            "availability_zone": "us-east-1e",
-            "instance_type": "t2.xlarge",
-            "root_block_device": [
-              {
-                "iops": 100,
-                "volume_size": 8,
-                "volume_type": "gp2"
+          "resources": [
+            {
+              "address": "module.instance.aws_instance.example",
+              "mode": "managed",
+              "type": "aws_instance",
+              "name": "example",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 1,
+              "values": {
+                "ami": "ami-2757f631",
+                "availability_zone": "us-east-1e",
+                "instance_type": "t2.xlarge",
+                "root_block_device": [
+                  {
+                    "iops": 100,
+                    "volume_size": 8,
+                    "volume_type": "gp2"
+                  }
+                ],
+                "tenancy": "default"
               }
-            ],
-            "tenancy": "default"
-          }
-        },
+            }
+          ],
+          "address": "module.instance"
+        }
+      ],
+      "resources": [
         {
           "address": "aws_lb.example",
           "mode": "managed",
@@ -41,7 +48,8 @@
   },
   "resource_changes": [
     {
-      "address": "aws_instance.example",
+      "address": "module.instance.aws_instance.example",
+      "module_address": "module.instance",
       "mode": "managed",
       "type": "aws_instance",
       "name": "example",
@@ -102,27 +110,32 @@
     "terraform_version": "0.12.28",
     "values": {
       "root_module": {
-        "resources": [
+        "child_modules": [
           {
-            "address": "aws_instance.example",
-            "mode": "managed",
-            "type": "aws_instance",
-            "name": "example",
-            "provider_name": "aws",
-            "schema_version": 1,
-            "values": {
-              "ami": "ami-2757f631",
-              "availability_zone": "us-east-1e",
-              "instance_type": "t2.micro",
-              "root_block_device": [
-                {
-                  "iops": 100,
-                  "volume_size": 8,
-                  "volume_type": "gp2"
+            "resources": [
+              {
+                "address": "module.instance.aws_instance.example",
+                "mode": "managed",
+                "type": "aws_instance",
+                "name": "example",
+                "provider_name": "aws",
+                "schema_version": 1,
+                "values": {
+                  "ami": "ami-2757f631",
+                  "availability_zone": "us-east-1e",
+                  "instance_type": "t2.micro",
+                  "root_block_device": [
+                    {
+                      "iops": 100,
+                      "volume_size": 8,
+                      "volume_type": "gp2"
+                    }
+                  ],
+                  "tenancy": "default"
                 }
-              ],
-              "tenancy": "default"
-            }
+              }
+            ],
+            "address": "module.instance"
           }
         ]
       }
@@ -154,23 +167,32 @@
       }
     },
     "root_module": {
+      "module_calls": {
+        "instance": {
+          "source": "./instance",
+          "module": {
+            "resources": [
+              {
+                "address": "aws_instance.example",
+                "mode": "managed",
+                "type": "aws_instance",
+                "name": "example",
+                "provider_config_key": "instance:aws",
+                "expressions": {
+                  "ami": {
+                    "constant_value": "ami-2757f631"
+                  },
+                  "instance_type": {
+                    "constant_value": "t2.xlarge"
+                  }
+                },
+                "schema_version": 1
+              }
+            ]
+          }
+        }
+      },
       "resources": [
-        {
-          "address": "aws_instance.example",
-          "mode": "managed",
-          "type": "aws_instance",
-          "name": "example",
-          "provider_config_key": "aws",
-          "expressions": {
-            "ami": {
-              "constant_value": "ami-2757f631"
-            },
-            "instance_type": {
-              "constant_value": "t2.xlarge"
-            }
-          },
-          "schema_version": 1
-        },
         {
           "address": "aws_lb.example",
           "mode": "managed",


### PR DESCRIPTION
This PR adds the child module support to the Terraform plan schema. It splits the `Plan.extractQueries` method into two: 

- `extractModuleConfiguration` - fills the `resourceProviders` map by recursively calling itself for each descendant of the root module
- `extractModuleQueries` - returns a list of resource queries by recursively calling itself for each descendant of the root module

Closes #37.