### PR TITLE
hcl: type/provider were missing for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+## [0.4.2] _2021-07-22_
+
+### Fixed
+
+- Add missing type/provider to resources in plans
+  ([Pull #54](https://github.com/cycloidio/terracost/pull/54))
+
 ## [0.4.1] _2021-07-15_
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.6.1
 	github.com/zclconf/go-cty v1.8.2
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/text v0.3.6
 )

--- a/terraform/hcl.go
+++ b/terraform/hcl.go
@@ -84,6 +84,8 @@ func extractHCLModule(providers map[string]Provider, parser *configs.Parser, mod
 			}
 			queries = append(queries, query.Resource{
 				Address:    addr,
+				Type:       rv.Type,
+				Provider:   rv.Provider.Type,
 				Components: comps,
 			})
 		}

--- a/terraform/hcl_test.go
+++ b/terraform/hcl_test.go
@@ -98,6 +98,10 @@ func TestExtractQueriesFromHCL(t *testing.T) {
 		queries, err := terraform.ExtractQueriesFromHCL(fs, providerInitializers, "../testdata/stack-test")
 		require.NoError(t, err)
 		require.Len(t, queries, 5)
+		for _, q := range queries {
+			require.Equal(t, "aws", q.Provider)
+			require.NotEmpty(t, q.Type)
+		}
 	})
 
 	t.Run("BadProvider", func(t *testing.T) {


### PR DESCRIPTION
The resources later converter to components had those fields set, but
the resource itself containing those components were missing it.