### PR TITLE
terraform: fix unexpected error with multiple providers

### DIFF
--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -240,6 +240,17 @@ func TestAWSEstimation(t *testing.T) {
 			assert.NoError(t, err)
 			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(32.374), "USD"), pcost)
 		})
+		t.Run("SuccessMagento", func(t *testing.T) {
+
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-magento", terraformAWSProviderInitializer)
+			require.NoError(t, err)
+
+			assert.Nil(t, plan.Prior)
+
+			pcost, err := plan.PlannedCost()
+			assert.NoError(t, err)
+			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(50.794), "USD"), pcost)
+		})
 	})
 }
 

--- a/terraform/provider.go
+++ b/terraform/provider.go
@@ -26,3 +26,15 @@ type ProviderInitializer struct {
 	// Provider initializes a Provider instance given the values defined in the config and returns it.
 	Provider func(values map[string]string) (Provider, error)
 }
+
+// validateProviders will verify that at least one of the queries is from a known provider
+// if none matches an error will be returned to stop the processing
+func validateProviders(queries []query.Resource, providers map[string]Provider) error {
+	for _, q := range queries {
+		_, ok := providers[q.Provider]
+		if ok {
+			return nil
+		}
+	}
+	return ErrNoKnownProvider
+}

--- a/testdata/aws/stack-magento/magento.tf
+++ b/testdata/aws/stack-magento/magento.tf
@@ -1,0 +1,126 @@
+module "magento" {
+
+  #####################################
+  # Do not modify the following lines #
+  source = "./module-magento"
+  env      = var.env
+  customer = var.customer
+  project  = var.project
+  #####################################
+
+  #. vpc_id (required):
+  #+ Amazon VPC id on which create each components.
+  vpc_id                   = "<vpc-id>"
+
+  #. private_subnets_ids (required, array):
+  #+ Amazon subnets IDs on which create each components.
+  private_subnets_ids      = ["private-subnets"]
+
+  #. magento_ssl_cert (required):
+  #+ ARN of an Amazon certificate from Certificate Manager.
+  magento_ssl_cert         = "<ssl-cert-arn>"
+
+  #. bastion_sg_allow (optional):
+  #+ Amazon source security group ID which will be allowed to connect on Magento front port 22 (ssh).
+  bastion_sg_allow         = "<bastion-sg>"
+
+  #. public_subnets_ids (required, array):
+  #+ Public subnet IDs to use for the public ELB load balancer.
+  public_subnets_ids       = ["public-subnets"]
+
+  #. rds_password (optional): var.rds_password to get it from the pipeline.
+  #+ Password of the RDS database.
+  rds_password             = var.rds_password
+
+  #. keypair_name (optional): demo
+  #+ SSH keypair name to use to deploy ec2 instances.
+  keypair_name = "demo"
+
+  #. extra_tags (optional): {}
+  #+ Dict of extra tags to add on aws resources. format { "foo" = "bar" }.
+
+  #. rds_database (optional): magento
+  #+ Name of the RDS database.
+  rds_database         = "magento"
+
+  #. rds_disk_size (optional): 10
+  #+ Size in Go of the RDS database.
+  rds_disk_size        = 10
+
+  #. rds_multiaz (optional, bool): false
+  #+ Enable multi AZ or not for the RDS database.
+  rds_multiaz          = false
+
+  #. rds_subnet_group (optional): Automatically generated from private_subnets_ids
+  #+ ID of the private DB subnet group to use for RDS database.
+  # rds_subnet_group           = "<rds-subnet-group>"
+
+  #. rds_type (optional): db.t3.small
+  #+ AWS Instance type of the RDS database.
+  rds_type             = "db.t3.small"
+
+  #. rds_username (optional): magento
+  #+ User name of the RDS database.
+  rds_username         = "magento"
+
+  #. rds_engine (optional): mysql
+  #+ Amazon RDS engine to use.
+  # rds_engine           = "mysql"
+
+  #. rds_engine_version (optional): "5.7.16"
+  #+ Version of the RDS engine.
+  rds_engine_version   = "5.7.16"
+
+  #. rds_backup_retention (optional): 7
+  #+ RDS backup retention period in days.
+  rds_backup_retention = 7
+
+  #. rds_parameters (optional):
+  #+ RDS parameters to assign to the RDS database.
+  rds_parameters       = ""
+
+
+  #. cache_subnet_group (optional): Automatically generated from private_subnets_ids
+  #+ AWS elasticache subnet name.
+  # cache_subnet_group                     = "cache-subnet-id"
+
+  #. elasticache_type (optional): cache.t2.micro
+  #+ AWS elasticache instance type.
+  elasticache_type                 = "cache.t2.micro"
+
+  #. elasticache_nodes (optional): 1
+  #+ Number of AWS elasticache instances.
+  elasticache_nodes                = "1"
+
+  #. elasticache_parameter_group_name (optional): default.redis5.0
+  #+ AWS elasticache parameter group name.
+  # elasticache_parameter_group_name = "default.redis5.0"
+
+  #. elasticache_engine (optional): redis
+  #+ AWS elasticache engine.
+  # elasticache_engine               = "redis"
+
+  #. elasticache_engine_version (optional): "5.0.0"
+  #+ AWS elasticache engine version.
+  elasticache_engine_version               = "5.0.0"
+
+  #. elasticache_engine (optional): 6379
+  #+ AWS elasticache binding port.
+  # elasticache_port                 = "6379"
+
+  #. front_count (optional): 1
+  #+ Number of Aws EC2 frontend server to create.
+  front_count           = "1"
+
+  #. front_disk_size (optional): 60
+  #+ Disk size in Go of Aws EC2 frontend servers.
+  front_disk_size       = 60
+
+  #. front_type (optional): t3.small
+  #+ Type of Aws EC2 frontend servers.
+  front_type            = "t3.small"
+
+  #. front_ebs_optimized (optional, bool): false
+  #+ Whether the Instance is EBS optimized or not, related to the instance type you choose.
+  front_ebs_optimized   = "false"
+}

--- a/testdata/aws/stack-magento/module-magento/ami.tf
+++ b/testdata/aws/stack-magento/module-magento/ami.tf
@@ -1,0 +1,26 @@
+data "aws_ami" "debian" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [var.debian_ami_name]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners = ["379101102735"] # Debian
+}
+

--- a/testdata/aws/stack-magento/module-magento/front.tf
+++ b/testdata/aws/stack-magento/module-magento/front.tf
@@ -1,0 +1,196 @@
+###
+
+# front
+
+###
+
+resource "aws_security_group" "front" {
+  name        = "${var.project}-front-${var.env}"
+  description = "Front ${var.env} for ${var.project}"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-front-${var.env}"
+    role = "front"
+  })
+}
+
+resource "aws_security_group_rule" "elb_to_front_http" {
+  type                     = "ingress"
+  from_port                = "80"
+  to_port                  = "80"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.elb-front.id
+  security_group_id        = aws_security_group.front.id
+}
+
+resource "aws_security_group_rule" "bastion_to_front_ssh" {
+  count                    = var.bastion_sg_allow != "" ? 1 : 0
+  type                     = "ingress"
+  from_port                = "22"
+  to_port                  = "22"
+  protocol                 = "tcp"
+  source_security_group_id = var.bastion_sg_allow
+  security_group_id        = aws_security_group.front.id
+}
+
+###
+
+# EC2
+
+###
+
+resource "aws_instance" "front" {
+  ami = data.aws_ami.debian.id
+
+  # associate_public_ip_address = false
+  count                = var.front_count
+  iam_instance_profile = aws_iam_instance_profile.front_profile.name
+  instance_type        = var.front_type
+  key_name             = var.keypair_name
+  ebs_optimized        = var.front_ebs_optimized
+
+  vpc_security_group_ids = compact([var.bastion_sg_allow, aws_security_group.front.id])
+
+  subnet_id = element(var.private_subnets_ids, count.index)
+
+  root_block_device {
+    volume_size           = var.front_disk_size
+    volume_type           = var.front_disk_type
+    delete_on_termination = true
+  }
+
+
+  volume_tags = merge(local.merged_tags, {
+    Name = "${var.project}-front${count.index}-${var.env}"
+    role = "front"
+  })
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-front${count.index}-${var.env}"
+    role = "front"
+  })
+}
+
+###
+
+# ELB
+
+###
+
+resource "aws_security_group" "elb-front" {
+  name        = "${var.project}-elb-front-${var.env}"
+  description = "Front ${var.env} for ${var.project}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-elb-front-${var.env}"
+    role = "front"
+  })
+
+}
+
+###
+
+# Create a loadbalancer for the fronts
+
+###
+
+resource "aws_elb" "front" {
+  name = "${var.project}-front-${var.env}"
+
+  listener {
+    lb_port           = 80
+    lb_protocol       = "tcp"
+    instance_port     = 80
+    instance_protocol = "tcp"
+  }
+
+  listener {
+    lb_port            = 443
+    lb_protocol        = "https"
+    instance_port      = 80
+    instance_protocol  = "http"
+    ssl_certificate_id = var.magento_ssl_cert
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "TCP:80"
+    interval            = 30
+  }
+
+  security_groups           = [aws_security_group.elb-front.id]
+  subnets                   = var.public_subnets_ids
+  instances                 = aws_instance.front.*.id
+  internal                  = false
+  cross_zone_load_balancing = true
+  idle_timeout              = 120
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-front-${var.env}"
+    role = "front"
+  })
+
+}
+
+###
+
+# Cloudwatch Alarms
+
+###
+
+variable "create_metric_alarm" {
+  default = true
+}
+
+resource "aws_cloudwatch_metric_alarm" "recover-front" {
+  count               = var.create_metric_alarm ? var.front_count : 0
+  depends_on          = [aws_instance.front]
+  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+  alarm_description   = "Recover the instance"
+  alarm_name          = "cycloid-engine_recover-${var.project}-front${count.index}-${var.env}"
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions = {
+    InstanceId = element(aws_instance.front.*.id, count.index)
+  }
+
+  evaluation_periods        = "2"
+  insufficient_data_actions = []
+  metric_name               = "StatusCheckFailed_System"
+  namespace                 = "AWS/EC2"
+  period                    = "60"
+  statistic                 = "Minimum"
+  threshold                 = "0"
+}

--- a/testdata/aws/stack-magento/module-magento/iam.tf
+++ b/testdata/aws/stack-magento/module-magento/iam.tf
@@ -1,0 +1,104 @@
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# Create IAM Role for front
+resource "aws_iam_role" "front" {
+  name               = "cycloid_${var.project}-${var.env}-front"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  path               = "/${var.project}/"
+}
+
+resource "aws_iam_instance_profile" "front_profile" {
+  name = "cycloid_profile-front-${var.project}-${var.env}"
+  role = aws_iam_role.front.name
+}
+
+# ec2 tag list policy
+data "aws_iam_policy_document" "ec2-tag-describe" {
+  statement {
+    actions = [
+      "ec2:DescribeTags",
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ec2-tag-describe" {
+  name        = "${var.env}-${var.project}-ec2-tag-describe"
+  path        = "/"
+  description = "EC2 tags Read only"
+  policy      = data.aws_iam_policy_document.ec2-tag-describe.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2-tag-describe" {
+  role       = aws_iam_role.front.name
+  policy_arn = aws_iam_policy.ec2-tag-describe.arn
+}
+
+#####################
+# Logs
+#####################
+
+data "aws_iam_policy_document" "push-logs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:UntagLogGroup",
+      "logs:TagLogGroup",
+      "logs:PutRetentionPolicy",
+      "logs:PutLogEvents",
+      "logs:DeleteRetentionPolicy",
+      "logs:CreateLogStream",
+    ]
+
+    resources = ["arn:aws:logs:*:*:log-group:${var.project}_${var.env}:*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:ListTagsLogGroup",
+      "logs:DescribeSubscriptionFilters",
+      "logs:DescribeMetricFilters",
+      "logs:DescribeLogStreams",
+      "logs:DescribeLogGroups",
+      "logs:TestMetricFilter",
+      "logs:DescribeResourcePolicies",
+      "logs:DescribeExportTasks",
+      "logs:DescribeDestinations",
+      "logs:CreateLogGroup",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "push-logs" {
+  name        = "${var.env}-${var.project}-push-logs"
+  path        = "/"
+  description = "Push log to cloudwatch"
+  policy      = data.aws_iam_policy_document.push-logs.json
+}
+
+resource "aws_iam_policy_attachment" "push-logs" {
+  name       = "${var.env}-${var.project}-push-logs"
+  roles      = [aws_iam_role.front.name]
+  policy_arn = aws_iam_policy.push-logs.arn
+}
+

--- a/testdata/aws/stack-magento/module-magento/outputs.tf
+++ b/testdata/aws/stack-magento/module-magento/outputs.tf
@@ -1,0 +1,45 @@
+# output "redis_magento_dns" {
+#   value = "${aws_route53_record.redis.fqdn}"
+# }
+#
+# output "rds_magento_dns" {
+#   value = "${aws_route53_record.rds.fqdn}"
+# }
+
+#ELB
+
+output "elb_front_dns_name" {
+  value = aws_elb.front.dns_name
+}
+
+output "elb_front_zone_id" {
+  value = aws_elb.front.zone_id
+}
+
+output "front_private_ips" {
+  value = join(",", aws_instance.front.*.private_ip)
+}
+
+output "rds_address" {
+  value = aws_db_instance.magento.address
+}
+
+output "rds_port" {
+  value = aws_db_instance.magento.port
+}
+
+output "rds_database" {
+  value = aws_db_instance.magento.name
+}
+
+output "rds_username" {
+  value = aws_db_instance.magento.username
+}
+
+output "cache_address" {
+  value = aws_elasticache_cluster.redis.cache_nodes[0].address
+}
+
+output "cache_cluster_id" {
+  value = local.elasticache_cluster_id
+}

--- a/testdata/aws/stack-magento/module-magento/rds.tf
+++ b/testdata/aws/stack-magento/module-magento/rds.tf
@@ -1,0 +1,63 @@
+###
+
+# RDS (mysql DB for magento)
+
+###
+
+resource "aws_security_group" "rds" {
+  name        = "${var.project}-rds-${var.env}"
+  description = "rds ${var.env} for ${var.project}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+
+    security_groups = [aws_security_group.front.id]
+  }
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-rds-${var.env}"
+    role = "rds"
+  })
+}
+
+resource "aws_db_instance" "magento" {
+  depends_on        = [aws_security_group.rds]
+  identifier        = "${var.project}-rds-${var.env}"
+  allocated_storage = var.rds_disk_size
+  storage_type      = var.rds_storage_type
+  engine            = var.rds_engine
+  engine_version    = var.rds_engine_version
+  instance_class    = var.rds_type
+  name              = var.rds_database
+  username          = var.rds_username
+  password          = var.rds_password
+
+  multi_az                  = var.rds_multiaz
+  apply_immediately         = true
+  maintenance_window        = "tue:06:00-tue:07:00"
+  backup_window             = "02:00-04:00"
+  backup_retention_period   = var.rds_backup_retention
+  copy_tags_to_snapshot     = true
+  final_snapshot_identifier = "${var.project}-rds-${var.env}"
+  skip_final_snapshot       = var.rds_skip_final_snapshot
+
+  parameter_group_name = var.rds_parameters
+  db_subnet_group_name = var.rds_subnet_group != "" ? var.rds_subnet_group : aws_db_subnet_group.rds-subnet[0].id
+
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-rds-${var.env}"
+    role = "rds"
+  })
+}
+
+resource "aws_db_subnet_group" "rds-subnet" {
+  name        = "rds-${var.project}-${var.vpc_id}-${var.env}"
+  count       = var.rds_subnet_group == "" ? 1 : 0
+  description = "subnet-rds-${var.project}-${var.env} ${var.vpc_id}"
+  subnet_ids  = var.private_subnets_ids
+}

--- a/testdata/aws/stack-magento/module-magento/redis.tf
+++ b/testdata/aws/stack-magento/module-magento/redis.tf
@@ -1,0 +1,46 @@
+resource "aws_security_group" "redis" {
+  name        = "${var.project}-${var.elasticache_engine}-${var.env}"
+  description = "${var.elasticache_engine} ${var.env} for ${var.project}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = var.elasticache_port
+    to_port   = var.elasticache_port
+    protocol  = "tcp"
+
+    security_groups = [
+      aws_security_group.front.id,
+    ]
+  }
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-${var.elasticache_engine}-${var.env}"
+    role = "redis"
+  })
+}
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = local.elasticache_cluster_id
+  engine               = var.elasticache_engine
+  engine_version       = var.elasticache_engine_version
+  node_type            = var.elasticache_type
+  port                 = var.elasticache_port
+  num_cache_nodes      = var.elasticache_nodes
+  parameter_group_name = var.elasticache_parameter_group_name
+  security_group_ids   = [aws_security_group.redis.id]
+  subnet_group_name    = var.cache_subnet_group != "" ? var.cache_subnet_group : aws_elasticache_subnet_group.cache-subnet[0].id
+  apply_immediately    = true
+  maintenance_window   = "tue:06:00-tue:07:00"
+
+  tags = merge(local.merged_tags, {
+    Name = "${var.project}-${var.elasticache_engine}-${var.env}"
+    role = "redis"
+  })
+}
+
+resource "aws_elasticache_subnet_group" "cache-subnet" {
+  name        = "cache-${var.project}-${var.vpc_id}-${var.env}"
+  count       = var.cache_subnet_group == "" ? 1 : 0
+  description = "redis cache subnet for ${var.project}-${var.env} ${var.vpc_id}"
+  subnet_ids  = var.private_subnets_ids
+}

--- a/testdata/aws/stack-magento/module-magento/variables.tf
+++ b/testdata/aws/stack-magento/module-magento/variables.tf
@@ -1,0 +1,193 @@
+data "aws_region" "current" {}
+
+variable "bastion_sg_allow" {
+}
+
+variable "env" {
+}
+
+variable "customer" {
+}
+
+variable "zones" {
+  type    = list(string)
+  default = []
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  aws_availability_zones = length(var.zones) > 0 ? var.zones : data.aws_availability_zones.available.names
+}
+
+variable "keypair_name" {
+  default = "demo"
+}
+
+variable "extra_tags" {
+  default = {}
+}
+
+locals {
+  standard_tags = {
+    "cycloid.io" = "true"
+    env          = var.env
+    project      = var.project
+    client       = var.customer
+  }
+  merged_tags = merge(local.standard_tags, var.extra_tags)
+}
+
+variable "private_subnets_ids" {
+  type    = list(string)
+  default = [""]
+}
+
+variable "public_subnets_ids" {
+  type = list(string)
+}
+
+# variable "private_zone_id" {}
+
+variable "cache_subnet_group" {
+  default = ""
+}
+
+variable "vpc_id" {
+  default = ""
+}
+
+variable "project" {
+  default = "magento"
+}
+
+variable "rds_database" {
+  default = "magento"
+}
+
+variable "rds_disk_size" {
+  default = 10
+}
+
+variable "rds_multiaz" {
+  default = false
+}
+
+variable "rds_password" {
+  default = "ChangeMePls"
+}
+
+variable "rds_type" {
+  default = "db.t3.small"
+}
+
+variable "rds_username" {
+  default = "magento"
+}
+
+variable "rds_engine" {
+  default = "mysql"
+}
+
+variable "rds_engine_version" {
+  default = "5.7.16"
+}
+
+variable "rds_backup_retention" {
+  default = 7
+}
+
+variable "rds_parameters" {
+  default = "default.mysql5.7"
+}
+
+variable "rds_subnet_group" {
+  default = ""
+}
+
+variable "rds_storage_type" {
+  default = "gp2"
+}
+
+variable "rds_skip_final_snapshot" {
+  default = false
+}
+
+###
+
+# front
+
+###
+
+variable "magento_ssl_cert" {
+}
+
+variable "front_disk_size" {
+  default = 60
+}
+
+variable "front_disk_type" {
+  default = "gp2"
+}
+
+variable "front_type" {
+  default = "t3.small"
+}
+
+variable "front_ebs_optimized" {
+  default = false
+}
+
+variable "front_count" {
+  default = 1
+}
+
+variable "debian_ami_name" {
+  default = "debian-stretch-*"
+}
+
+###
+
+# ElastiCache
+
+###
+
+variable "elasticache_type" {
+  default = "cache.t2.micro"
+}
+
+variable "elasticache_nodes" {
+  default = 1
+}
+
+variable "elasticache_engine" {
+  default = "redis"
+}
+
+variable "elasticache_parameter_group_name" {
+  default = "default.redis5.0"
+}
+
+variable "elasticache_engine_version" {
+  default = "5.0.0"
+}
+
+variable "elasticache_port" {
+  default = "6379"
+}
+
+variable "elasticache_cluster_id" {
+  default = ""
+}
+
+resource "random_string" "elasticache_cluster_id" {
+  length  = 18
+  upper   = false
+  special = false
+}
+
+locals {
+  elasticache_cluster_id = var.elasticache_cluster_id != "" ? var.elasticache_cluster_id : "cy${random_string.elasticache_cluster_id.result}"
+}

--- a/testdata/aws/stack-magento/outputs.tf
+++ b/testdata/aws/stack-magento/outputs.tf
@@ -1,0 +1,49 @@
+output "elb_front_dns_name" {
+  value       = module.magento.elb_front_dns_name
+  description = "DNS name of the front elb."
+}
+
+output "elb_front_zone_id" {
+  value       = module.magento.elb_front_zone_id
+  description = "Zone ID of the front ELB."
+}
+
+output "front_private_ips" {
+  value       = module.magento.front_private_ips
+  description = "Private IPs of the front EC2 server."
+}
+
+output "cache_address" {
+  value       = module.magento.cache_address
+  description = "Address of the ElastiCache."
+}
+
+output "cache_cluster_id" {
+  value       = module.magento.cache_cluster_id
+  description = "Cluster Id of the ElastiCache."
+}
+
+output "rds_address" {
+  value       = module.magento.rds_address
+  description = "Address of the RDS database."
+}
+
+output "rds_port" {
+  value       = module.magento.rds_port
+  description = "Port of the RDS database."
+}
+
+output "rds_username" {
+  value       = module.magento.rds_username
+  description = "Username of the RDS database."
+}
+
+output "rds_password" {
+  value     = var.rds_password
+  sensitive = true
+}
+
+output "rds_database" {
+  value       = module.magento.rds_database
+  description = "Database name of the RDS database."
+}

--- a/testdata/aws/stack-magento/provider.tf
+++ b/testdata/aws/stack-magento/provider.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  #version    = "1.40.0"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region
+}
+
+variable "customer" {
+}
+
+variable "project" {
+}
+
+variable "env" {
+}
+
+variable "access_key" {
+}
+
+variable "secret_key" {
+}
+
+variable "rds_password" {
+  default = "ChangeMePls"
+}
+
+variable "aws_region" {
+  description = "AWS region to launch servers."
+  default     = "eu-west-1"
+}

--- a/testdata/aws/stack-magento/versions.tf
+++ b/testdata/aws/stack-magento/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 1.0"
+}


### PR DESCRIPTION
If using another provider (e.g. 'random'), the execution would stop because of the recursion of the function, so using the flag logic doesn't work as expected when multiple providers are mixed.

Instead that logic has been extracted afterwards, to ensure that at least one of the queries is of a known provider's type.

Closes: https://github.com/cycloidio/terracost/issues/56