### PR TITLE
providers: ignore "constraint providers"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+### Fixed
+
+- Ignore providers related to constraints
+  ([Pull #58](https://github.com/cycloidio/terracost/pull/58))
+- Unexpected error when using supported/unsupported providers
+  ([Pull #56](https://github.com/cycloidio/terracost/pull/56))
+
+## [0.4.3] _2021-08-30_
+
+### Changed
+
+- Improved error returned when using unknown providers, empty terraform
+  ([Pull #55](https://github.com/cycloidio/terracost/pull/55))
+
 ## [0.4.2] _2021-07-22_
 
 ### Fixed

--- a/aws/terraform_provider.go
+++ b/aws/terraform_provider.go
@@ -13,7 +13,11 @@ const RegistryName = "registry.terraform.io/hashicorp/aws"
 var TerraformProviderInitializer = terraform.ProviderInitializer{
 	MatchNames: []string{ProviderName, RegistryName},
 	Provider: func(values map[string]string) (terraform.Provider, error) {
-		regCode := region.Code(values["region"])
+		r, ok := values["region"]
+		if !ok {
+			return nil, nil
+		}
+		regCode := region.Code(r)
 		return awstf.NewProvider(ProviderName, regCode)
 	},
 }

--- a/terraform/error.go
+++ b/terraform/error.go
@@ -6,4 +6,5 @@ import "errors"
 var (
 	ErrNoQueries       = errors.New("no terraform entities found, looks empty")
 	ErrNoKnownProvider = errors.New("terraform providers are not yet supported")
+	ErrNoProviders     = errors.New("no valid providers found")
 )

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -45,11 +45,7 @@ func (p *Plan) ExtractPlannedQueries() ([]query.Resource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to extract planned queries: %w", err)
 	}
-	queries, err := p.extractQueries(p.PlannedValues, providers), nil
-	if err != nil {
-		return nil, err
-	}
-	return queries, nil
+	return p.extractQueries(p.PlannedValues, providers), nil
 }
 
 // ExtractPriorQueries extracts a query.Resource slice from the `prior_state` part of the Plan.
@@ -77,8 +73,13 @@ func (p *Plan) extractProviders() (map[string]Provider, error) {
 			if err != nil {
 				return nil, err
 			}
-			providers[name] = prov
+			if prov != nil {
+				providers[name] = prov
+			}
 		}
+	}
+	if len(providers) == 0 {
+		return nil, ErrNoProviders
 	}
 	return providers, nil
 }

--- a/terraform/provider.go
+++ b/terraform/provider.go
@@ -24,6 +24,7 @@ type ProviderInitializer struct {
 	MatchNames []string
 
 	// Provider initializes a Provider instance given the values defined in the config and returns it.
+	// If a provider must be ignored (related to version constraints, etc), please return nil to avoid using it.
 	Provider func(values map[string]string) (Provider, error)
 }
 

--- a/testdata/aws/terraform-plan-noprovider.json
+++ b/testdata/aws/terraform-plan-noprovider.json
@@ -142,34 +142,7 @@
     }
   },
   "configuration": {
-    "provider_config": {
-      "aws": {
-        "name": "aws-test",
-        "expressions": {
-          "profile": {
-            "constant_value": "default"
-          },
-          "region": {
-            "constant_value": "us-east-1"
-          }
-        }
-      },
-      "aws.paris": {
-        "name": "aws-test",
-        "expressions": {
-          "profile": {
-            "constant_value": "default"
-          },
-          "region": {
-            "constant_value": "eu-west-3"
-          }
-        }
-      },
-      "ignored": {
-        "name": "aws-constrain",
-        "version_constraint": ">= 1.1.1",
-        "module_address": "some-module"
-      }
+    "provider_config": {}
     },
     "root_module": {
       "module_calls": {


### PR DESCRIPTION
Certain providers of Terraform are meant to specify constraint rather
than locations/regions, etc. In cases where a provider doesn't contain a
valid location, it will not be added to the list of valid providers, if
no providers at all exist an error will be returned mentioning it.