### PR TITLE
mod: Do not import a fork of TF but another version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.1
-	github.com/hashicorp/terraform v1.0.11
+	github.com/hashicorp/terraform v0.15.3
 	github.com/lopezator/migrator v0.3.0
 	github.com/machinebox/progress v0.2.0
 	github.com/matryer/is v1.4.0 // indirect
@@ -40,5 +40,3 @@ require (
 	google.golang.org/grpc v1.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/hashicorp/terraform => github.com/hashicorp/terraform v0.15.3


### PR DESCRIPTION
We had the fork as the newer versions cannot be imported, so just using an old one
should do the trick.

Closes #74 