### PR TITLE
Fixed issue with weak types on user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Plan variables where forced to be `string` and if not was failing
   ([Issue #86](https://github.com/cycloidio/terracost/issues/86))
+- Added weak type conversion for values when calculation price from the user inputs
+  ([Pull #89](https://github.com/cycloidio/terracost/pull/89))
 
 ## [0.5.1] _2023-03-08_
 

--- a/aws/terraform/autoscaling_group.go
+++ b/aws/terraform/autoscaling_group.go
@@ -44,7 +44,17 @@ type autoscalingGroupValues struct {
 // decodeAutoscalingGroupValues decodes and returns instanceValues from a Terraform values map.
 func decodeAutoscalingGroupValues(tfVals map[string]interface{}) (autoscalingGroupValues, error) {
 	var v autoscalingGroupValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/db_instance.go
+++ b/aws/terraform/db_instance.go
@@ -79,7 +79,17 @@ var licenseModelMap = map[string]string{
 
 func decodeDBInstanceValues(tfVals map[string]interface{}) (dbInstanceValues, error) {
 	var v dbInstanceValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/eip.go
+++ b/aws/terraform/eip.go
@@ -28,7 +28,17 @@ type elasticIPValues struct {
 
 func decodeElasticIPValues(tfVals map[string]interface{}) (elasticIPValues, error) {
 	var v elasticIPValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/elasticache_cluster.go
+++ b/aws/terraform/elasticache_cluster.go
@@ -48,7 +48,17 @@ var cacheTypeMap = map[string]string{
 
 func decodeElastiCacheValues(tfVals map[string]interface{}) (elastiCacheValues, error) {
 	var v elastiCacheValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/elasticache_replication_group.go
+++ b/aws/terraform/elasticache_replication_group.go
@@ -46,7 +46,17 @@ type elastiCacheReplicationValues struct {
 
 func decodeElastiCacheReplicationValues(tfVals map[string]interface{}) (elastiCacheReplicationValues, error) {
 	var v elastiCacheReplicationValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/instance.go
+++ b/aws/terraform/instance.go
@@ -75,9 +75,20 @@ type instanceValues struct {
 // decodeInstanceValues decodes and returns instanceValues from a Terraform values map.
 func decodeInstanceValues(tfVals map[string]interface{}) (instanceValues, error) {
 	var v instanceValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
 		return v, err
 	}
+
+	if err := decoder.Decode(tfVals); err != nil {
+		return v, err
+	}
+
 	return v, nil
 }
 

--- a/aws/terraform/launch_configuration.go
+++ b/aws/terraform/launch_configuration.go
@@ -22,7 +22,17 @@ type launchConfigurationValues struct {
 // decodeAutoscalingGroupValues decodes and returns instanceValues from a Terraform values map.
 func decodeLaunchConfigurationValues(tfVals map[string]interface{}) (launchConfigurationValues, error) {
 	var v launchConfigurationValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/launch_template.go
+++ b/aws/terraform/launch_template.go
@@ -33,7 +33,17 @@ type launchTemplateValues struct {
 // decodeAutoscalingGroupValues decodes and returns instanceValues from a Terraform values map.
 func decodeLaunchTemplateValues(tfVals map[string]interface{}) (launchTemplateValues, error) {
 	var v launchTemplateValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/lb.go
+++ b/aws/terraform/lb.go
@@ -30,7 +30,17 @@ type lbValues struct {
 // decodeLBValues decodes and returns lbValues from a Terraform values map.
 func decodeLBValues(tfVals map[string]interface{}) (lbValues, error) {
 	var v lbValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/aws/terraform/provider.go
+++ b/aws/terraform/provider.go
@@ -34,6 +34,7 @@ func (p *Provider) ResourceComponents(rss map[string]terraform.Resource, tfRes t
 		if err != nil {
 			return nil
 		}
+
 		return p.newInstance(vals).Components()
 	case "aws_autoscaling_group":
 		vals, err := decodeAutoscalingGroupValues(tfRes.Values)

--- a/aws/terraform/volume.go
+++ b/aws/terraform/volume.go
@@ -31,7 +31,17 @@ type volumeValues struct {
 // decodeVolumeValues decodes and returns volumeValues from a Terraform values map.
 func decodeVolumeValues(tfVals map[string]interface{}) (volumeValues, error) {
 	var v volumeValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/azurerm/terraform/linux_virtual_machine.go
+++ b/azurerm/terraform/linux_virtual_machine.go
@@ -28,7 +28,17 @@ type linuxVirtualMachineValues struct {
 // decodeLinuxVirtualMachineValues decodes and returns computeInstanceValues from a Terraform values map.
 func decodeLinuxVirtualMachineValues(tfVals map[string]interface{}) (linuxVirtualMachineValues, error) {
 	var v linuxVirtualMachineValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/azurerm/terraform/virtual_machine.go
+++ b/azurerm/terraform/virtual_machine.go
@@ -24,7 +24,17 @@ type virtualMachineValues struct {
 // decodeVirtualMachineValues decodes and returns computeInstanceValues from a Terraform values map.
 func decodeVirtualMachineValues(tfVals map[string]interface{}) (virtualMachineValues, error) {
 	var v virtualMachineValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -285,7 +285,7 @@ func TestAWSEstimation(t *testing.T) {
 
 			pcost, err := plan.PlannedCost()
 			assert.NoError(t, err)
-			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(73.334), "USD"), pcost)
+			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(86.474), "USD"), pcost)
 		})
 		t.Run("SuccessASG", func(t *testing.T) {
 
@@ -296,7 +296,7 @@ func TestAWSEstimation(t *testing.T) {
 
 			pcost, err := plan.PlannedCost()
 			assert.NoError(t, err)
-			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(764.863), "USD"), pcost)
+			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(691.863), "USD"), pcost)
 		})
 		t.Run("SuccessRemote", func(t *testing.T) {
 
@@ -307,7 +307,7 @@ func TestAWSEstimation(t *testing.T) {
 
 			pcost, err := plan.PlannedCost()
 			assert.NoError(t, err)
-			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(764.863), "USD"), pcost)
+			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(86.474), "USD"), pcost)
 		})
 	})
 }

--- a/estimation.go
+++ b/estimation.go
@@ -56,6 +56,10 @@ func EstimateHCL(ctx context.Context, be backend.Backend, fs afero.Fs, path stri
 		providerInitializers = getDefaultProviders()
 	}
 
+	if fs == nil {
+		fs = afero.NewOsFs()
+	}
+
 	plannedQueries, err := terraform.ExtractQueriesFromHCL(fs, providerInitializers, path)
 	if err != nil {
 		return nil, err

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,20 @@
 # TerraCost examples
 
-Examples help you to understand how to test Terracost.
+Examples help you to understand how to test TerraCost.
 
 ## Requirements
 
 ### Mysql
 
-Cloud Provider pricing datas need to be ingested in a Mysql server. For testing purpose, local docker can be used
+Cloud Provider pricing data need to be ingested in a Mysql server. For testing purpose, local docker can be used
 
 ```
-docker run  -p 3306:3306 -d --privileged  -e MYSQL_ROOT_PASSWORD=password  mysql:8.0.21 --default-authentication-plugin=mysql_native_password
+docker run  -p 3306:3306 -d --privileged  -e MYSQL_ROOT_PASSWORD=terracost  mysql:8.0.21 --default-authentication-plugin=mysql_native_password
+```
 
-# Once Mysql started, create the terracost database
-mysql -h 127.0.0.1 -uroot -ppassword -e "CREATE DATABASE terracost"
+Once Mysql started, create the terracost database
+```
+mysql -h 127.0.0.1 -uroot -pterracost -e "CREATE DATABASE terracost_test"
 ```
 
 ## Examples
@@ -21,21 +23,17 @@ mysql -h 127.0.0.1 -uroot -ppassword -e "CREATE DATABASE terracost"
 
 To start prices ingestion you need to first decide which cloud provider to ingest. In the example `AWS` is available with `-ingest-aws`.
 
- and services
-
- in `terracost-ingester.go`
-
 ```
 go run terracost.go -ingest-aws
 ```
 
-Here we ingest all supported services by Terracost, ingestion could takes severals minutes depending the amonts of datas.
-If you don't need all services, the list could be defined to reduce time.
+Here we ingest all supported services by TerraCost, ingestion could takes several minutes depending the amounts of data.
+If you don't need all services you can run it with `-minimal` which will run just the small subset needed for it work.
 
 > Note
 > Before to ingest datas, the database migrations are needed. In order to correctly run migrations, we need `?multiStatements=true` param on DB connector
 > ```
-> sql.Open("mysql", "root:password@tcp(127.0.0.1:3306)/terracost?multiStatements=true")
+> sql.Open("mysql", "root:terracost@tcp(127.0.0.1:3306)/terracost_test?multiStatements=true")
 > ```
 
 ### Pricing Estimation (from Plan)

--- a/google/terraform/compute_instance.go
+++ b/google/terraform/compute_instance.go
@@ -28,7 +28,17 @@ type computeInstanceValues struct {
 // decodeComputeInstanceValues decodes and returns computeInstanceValues from a Terraform values map.
 func decodeComputeInstanceValues(tfVals map[string]interface{}) (computeInstanceValues, error) {
 	var v computeInstanceValues
-	if err := mapstructure.Decode(tfVals, &v); err != nil {
+	config := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           &v,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return v, err
+	}
+
+	if err := decoder.Decode(tfVals); err != nil {
 		return v, err
 	}
 	return v, nil

--- a/testdata/aws/stack-magento/magento.tf
+++ b/testdata/aws/stack-magento/magento.tf
@@ -2,7 +2,7 @@ module "magento" {
 
   #####################################
   # Do not modify the following lines #
-  source = "./module-magento"
+  source   = "./module-magento"
   env      = var.env
   customer = var.customer
   project  = var.project
@@ -10,27 +10,27 @@ module "magento" {
 
   #. vpc_id (required):
   #+ Amazon VPC id on which create each components.
-  vpc_id                   = "vpc-id"
+  vpc_id = "vpc-id"
 
   #. private_subnets_ids (required, array):
   #+ Amazon subnets IDs on which create each components.
-  private_subnets_ids      = ["private-subnets"]
+  private_subnets_ids = ["private-subnets"]
 
   #. magento_ssl_cert (required):
   #+ ARN of an Amazon certificate from Certificate Manager.
-  magento_ssl_cert         = "ssl-cert-arn"
+  magento_ssl_cert = "ssl-cert-arn"
 
   #. bastion_sg_allow (optional):
   #+ Amazon source security group ID which will be allowed to connect on Magento front port 22 (ssh).
-  bastion_sg_allow         = "bastion-sg"
+  bastion_sg_allow = "bastion-sg"
 
   #. public_subnets_ids (required, array):
   #+ Public subnet IDs to use for the public ELB load balancer.
-  public_subnets_ids       = ["public-subnets"]
+  public_subnets_ids = ["public-subnets"]
 
   #. rds_password (optional): var.rds_password to get it from the pipeline.
   #+ Password of the RDS database.
-  rds_password             = var.rds_password
+  rds_password = var.rds_password
 
   #. keypair_name (optional): demo
   #+ SSH keypair name to use to deploy ec2 instances.
@@ -41,15 +41,15 @@ module "magento" {
 
   #. rds_database (optional): magento
   #+ Name of the RDS database.
-  rds_database         = "magento"
+  rds_database = "magento"
 
   #. rds_disk_size (optional): 10
   #+ Size in Go of the RDS database.
-  rds_disk_size        = 10
+  rds_disk_size = 10
 
   #. rds_multiaz (optional, bool): false
   #+ Enable multi AZ or not for the RDS database.
-  rds_multiaz          = false
+  rds_multiaz = false
 
   #. rds_subnet_group (optional): Automatically generated from private_subnets_ids
   #+ ID of the private DB subnet group to use for RDS database.
@@ -57,11 +57,11 @@ module "magento" {
 
   #. rds_type (optional): db.t3.small
   #+ AWS Instance type of the RDS database.
-  rds_type             = "db.t3.small"
+  rds_type = "db.t3.small"
 
   #. rds_username (optional): magento
   #+ User name of the RDS database.
-  rds_username         = "magento"
+  rds_username = "magento"
 
   #. rds_engine (optional): mysql
   #+ Amazon RDS engine to use.
@@ -69,7 +69,7 @@ module "magento" {
 
   #. rds_engine_version (optional): "5.7.16"
   #+ Version of the RDS engine.
-  rds_engine_version   = "5.7.16"
+  rds_engine_version = "5.7.16"
 
   #. rds_backup_retention (optional): 7
   #+ RDS backup retention period in days.
@@ -77,7 +77,7 @@ module "magento" {
 
   #. rds_parameters (optional):
   #+ RDS parameters to assign to the RDS database.
-  rds_parameters       = ""
+  rds_parameters = ""
 
 
   #. cache_subnet_group (optional): Automatically generated from private_subnets_ids
@@ -86,11 +86,11 @@ module "magento" {
 
   #. elasticache_type (optional): cache.t2.micro
   #+ AWS elasticache instance type.
-  elasticache_type                 = "cache.t2.micro"
+  elasticache_type = "cache.t2.micro"
 
   #. elasticache_nodes (optional): 1
   #+ Number of AWS elasticache instances.
-  elasticache_nodes                = "1"
+  elasticache_nodes = "1"
 
   #. elasticache_parameter_group_name (optional): default.redis5.0
   #+ AWS elasticache parameter group name.
@@ -102,7 +102,7 @@ module "magento" {
 
   #. elasticache_engine_version (optional): "5.0.0"
   #+ AWS elasticache engine version.
-  elasticache_engine_version               = "5.0.0"
+  elasticache_engine_version = "5.0.0"
 
   #. elasticache_engine (optional): 6379
   #+ AWS elasticache binding port.
@@ -110,17 +110,17 @@ module "magento" {
 
   #. front_count (optional): 1
   #+ Number of Aws EC2 frontend server to create.
-  front_count           = "1"
+  front_count = "1"
 
   #. front_disk_size (optional): 60
   #+ Disk size in Go of Aws EC2 frontend servers.
-  front_disk_size       = 60
+  front_disk_size = "60"
 
   #. front_type (optional): t3.small
   #+ Type of Aws EC2 frontend servers.
-  front_type            = "t3.small"
+  front_type = "t3.small"
 
   #. front_ebs_optimized (optional, bool): false
   #+ Whether the Instance is EBS optimized or not, related to the instance type you choose.
-  front_ebs_optimized   = true
+  front_ebs_optimized = true
 }


### PR DESCRIPTION
We used specific typing which when failed to convert ignored the resource price calculation, now we have weak type (`"20"` to `20` for example) which means it's more align with Terraform type system.