### PR TITLE
usage: Added 'Usage' struct to hold all the supported usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support for remote module references
   ([Issue #88](https://github.com/cycloidio/terracost/issues/88))
+- Added 'Usage' support for those options that are not from configuration but from usage of the resource
+  ([Issue #96](https://github.com/cycloidio/terracost/issues/96))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ for _, res := range plan.ResourceDifferences() {
 
 Check the documentation for all available fields.
 
+### Usage estimation
+
+Some resources do cannot be estimated just by the configuration and need some extra usage information, for that we have some default on `usage/usage.go` which are also all the resources and options we support currently and can be overwritten when estimating if passing a custom one instead of the custom Default one.
+
 ## Examples
 
 For more examples, please check [examples](examples/README.md).

--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cycloidio/terracost/price"
 	"github.com/cycloidio/terracost/product"
 	"github.com/cycloidio/terracost/terraform"
+	"github.com/cycloidio/terracost/usage"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,7 +143,7 @@ func TestAWSEstimation(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, terraformAWSTestProviderInitializer)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default, terraformAWSTestProviderInitializer)
 			require.NoError(t, err)
 
 			pcost, err := plan.PriorCost()
@@ -217,7 +218,7 @@ func TestAWSEstimation(t *testing.T) {
 					return awstf.NewProvider(aws.ProviderName, regCode)
 				},
 			}
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, tfpi)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default, tfpi)
 			require.NoError(t, err)
 
 			pcost, err := plan.PriorCost()
@@ -237,7 +238,7 @@ func TestAWSEstimation(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default)
 			require.NoError(t, err)
 
 			pcost, err := plan.PriorCost()
@@ -258,7 +259,7 @@ func TestAWSEstimation(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, terraformAWSTestProviderInitializer)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default, terraformAWSTestProviderInitializer)
 			require.NoError(t, err)
 
 			diffs := plan.ResourceDifferences()
@@ -280,7 +281,7 @@ func TestAWSEstimation(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, terraformAWSTestProviderInitializer)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default, terraformAWSTestProviderInitializer)
 			require.Error(t, err, terraform.ErrNoProviders)
 			require.Nil(t, plan)
 		})
@@ -288,7 +289,7 @@ func TestAWSEstimation(t *testing.T) {
 	t.Run("HCL", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-aws")
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-aws", usage.Default)
 			require.NoError(t, err)
 
 			assert.Nil(t, plan.Prior)
@@ -299,7 +300,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessMagento", func(t *testing.T) {
 
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-magento")
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-magento", usage.Default)
 			require.NoError(t, err)
 
 			assert.Nil(t, plan.Prior)
@@ -310,7 +311,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessASG", func(t *testing.T) {
 
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-asg")
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-asg", usage.Default)
 			require.NoError(t, err)
 
 			assert.Nil(t, plan.Prior)
@@ -321,7 +322,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessRemote", func(t *testing.T) {
 
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-remote")
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-remote", usage.Default)
 			require.NoError(t, err)
 
 			assert.Nil(t, plan.Prior)

--- a/e2e/azurerm_estimation_test.go
+++ b/e2e/azurerm_estimation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cycloidio/terracost/cost"
 	"github.com/cycloidio/terracost/mysql"
 	"github.com/cycloidio/terracost/testutil"
+	"github.com/cycloidio/terracost/usage"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func TestAzureRMEstimation(t *testing.T) {
 		require.NoError(t, err)
 		defer f.Close()
 
-		plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f)
+		plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default)
 		require.NoError(t, err)
 
 		pcost, err := plan.PriorCost()
@@ -56,7 +57,7 @@ func TestAzureRMEstimation(t *testing.T) {
 		assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(64.021), "USD"), pcost)
 	})
 	t.Run("FromHCL", func(t *testing.T) {
-		plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/azurerm/stack-compute")
+		plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/azurerm/stack-compute", usage.Default)
 		require.NoError(t, err)
 
 		assert.Nil(t, plan.Prior)

--- a/e2e/gcp_estimation_test.go
+++ b/e2e/gcp_estimation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cycloidio/terracost/google"
 	"github.com/cycloidio/terracost/mysql"
 	"github.com/cycloidio/terracost/testutil"
+	"github.com/cycloidio/terracost/usage"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func TestGoogleEstimation(t *testing.T) {
 		require.NoError(t, err)
 		defer f.Close()
 
-		plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f)
+		plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default)
 		require.NoError(t, err)
 
 		pcost, err := plan.PriorCost()
@@ -59,7 +60,7 @@ func TestGoogleEstimation(t *testing.T) {
 		assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(39.7258116), "USD"), pcost)
 	})
 	t.Run("FromHCL", func(t *testing.T) {
-		plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/google/stack-compute")
+		plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/google/stack-compute", usage.Default)
 		require.NoError(t, err)
 
 		assert.Nil(t, plan.Prior)

--- a/e2e/invalid_estimation_test.go
+++ b/e2e/invalid_estimation_test.go
@@ -9,6 +9,7 @@ import (
 	costestimation "github.com/cycloidio/terracost"
 	"github.com/cycloidio/terracost/mysql"
 	"github.com/cycloidio/terracost/terraform"
+	"github.com/cycloidio/terracost/usage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,7 @@ func TestVMWareEstimation(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, terraformAWSTestProviderInitializer)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default, terraformAWSTestProviderInitializer)
 			require.Error(t, err, terraform.ErrNoQueries)
 			assert.Nil(t, plan)
 		})
@@ -42,7 +43,7 @@ func TestVMWareEstimation(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, terraformAWSTestProviderInitializer)
+			plan, err := costestimation.EstimateTerraformPlan(ctx, backend, f, usage.Default, terraformAWSTestProviderInitializer)
 			require.Error(t, err, terraform.ErrNoKnownProvider)
 			assert.Nil(t, plan)
 		})
@@ -50,12 +51,12 @@ func TestVMWareEstimation(t *testing.T) {
 
 	t.Run("HCL", func(t *testing.T) {
 		t.Run("UnsupportedProvider", func(t *testing.T) {
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-vmware")
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-vmware", usage.Default)
 			assert.Nil(t, plan)
 			assert.Error(t, err, terraform.ErrNoKnownProvider)
 		})
 		t.Run("EmptyTerraform", func(t *testing.T) {
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-empty")
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-empty", usage.Default)
 			assert.Nil(t, plan)
 			assert.Error(t, err, terraform.ErrNoQueries)
 		})

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -7,17 +7,22 @@ import (
 	"strings"
 
 	"github.com/cycloidio/terracost/query"
+	"github.com/cycloidio/terracost/usage"
 )
 
 // Plan is a representation of a Terraform plan file.
 type Plan struct {
 	providerInitializers map[string]ProviderInitializer
+	usage                usage.Usage
 
 	Configuration Configuration       `json:"configuration"`
 	PriorState    *State              `json:"prior_state"`
 	PlannedValues Values              `json:"planned_values"`
 	Variables     map[string]Variable `json:"variables"`
 }
+
+// SetUsage will set the usage of the plan
+func (p *Plan) SetUsage(u usage.Usage) { p.usage = u }
 
 // NewPlan returns an empty Plan.
 func NewPlan(providerInitializers ...ProviderInitializer) *Plan {
@@ -142,6 +147,7 @@ func (p *Plan) extractModuleQueries(module *Module, resourceProviders map[string
 			continue
 		}
 
+		tfres.Values[usage.Key] = p.usage.GetUsage(tfres.Type)
 		comps := provider.ResourceComponents(nil, tfres)
 		q := query.Resource{
 			Address:    tfres.Address,

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -1,0 +1,43 @@
+package usage
+
+const (
+	// Key is the key used to set the usage
+	// on the values passed to the resources
+	Key string = "usage"
+)
+
+// Default is the default Usage that will be used if none is configured
+var Default = Usage{
+	ResourceDefaultTypeUsage: map[string]interface{}{
+		"aws_eks_node_group": map[string]interface{}{
+			"instances":                        15,
+			"operating_system":                 "linux",
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "partial_upfront",
+			"monthly_cpu_credit_hrs":           350,
+			"vcpu_count":                       2,
+		},
+		"aws_efs_file_system": map[string]interface{}{
+			"storage_gb":                         230,
+			"infrequent_access_storage_gb":       100,
+			"monthly_infrequent_access_read_gb":  50,
+			"monthly_infrequent_access_write_gb": 100,
+		},
+	},
+}
+
+// Usage is the struct defining all the configure usages
+type Usage struct {
+	ResourceDefaultTypeUsage map[string]interface{} `json:"resource_default_type_usage",yaml:"resource_default_type_usage"`
+}
+
+// GetUsage will return the usage from the resource rt (ex: aws_instance)
+func (u Usage) GetUsage(rt string) map[string]interface{} {
+	us, ok := u.ResourceDefaultTypeUsage[rt]
+	if ok {
+		return us.(map[string]interface{})
+	}
+
+	return nil
+}

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -1,0 +1,23 @@
+package usage_test
+
+import (
+	"testing"
+
+	"github.com/cycloidio/terracost/usage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUsage(t *testing.T) {
+	eu := map[string]interface{}{
+		"something": "else",
+	}
+	us := usage.Usage{
+		ResourceDefaultTypeUsage: map[string]interface{}{
+			"aws_instance": eu,
+		},
+	}
+
+	ru := us.GetUsage("aws_instance")
+	assert.Equal(t, eu, ru)
+
+}


### PR DESCRIPTION
This is passed when estimating HCL and Plan so they can be conputed with the rest of the configuration

Closes #96 