### PR TITLE
terraform/hcl: The 'dir' on the FS was expected to not be the '' one before

### DIFF
--- a/terraform/hcl.go
+++ b/terraform/hcl.go
@@ -251,7 +251,7 @@ func installModule(fs afero.Fs, mc *configs.ModuleCall) (string, error) {
 	defer os.RemoveAll(dir)
 
 	fs.MkdirAll(dir, 0700)
-	err = util.FromOSToAfero(fs, dir, "")
+	err = util.FromOSToAfero(fs, dir, dir)
 	if err != nil {
 		return "", fmt.Errorf("failed to copy the module to %s: %w", dir, err)
 	}


### PR DESCRIPTION

As the caller assumes the 'dir' retunred is the one used to store the values