### PR TITLE
Follow HCL references | Add `for_each` estimation | Fix variable weak typing

### DIFF
--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -25,6 +25,7 @@ import (
 var (
 	noModulePath            = ""
 	noForceTerragrunt       bool
+	noDebug                 bool
 	noParallelismTerragrunt = 0
 )
 
@@ -326,7 +327,7 @@ func TestAWSEstimation(t *testing.T) {
 	t.Run("HCL", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 
-			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-aws", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-aws", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			require.NoError(t, err)
 			require.Len(t, plans, 1)
 			plan := plans[0]
@@ -339,7 +340,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessMagento", func(t *testing.T) {
 
-			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-magento", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-magento", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			require.NoError(t, err)
 			require.Len(t, plans, 1)
 			plan := plans[0]
@@ -352,7 +353,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessASG", func(t *testing.T) {
 
-			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-asg", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-asg", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			require.NoError(t, err)
 			require.Len(t, plans, 1)
 			plan := plans[0]
@@ -365,7 +366,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessEKS", func(t *testing.T) {
 
-			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-eks", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-eks", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			require.NoError(t, err)
 			require.Len(t, plans, 1)
 			plan := plans[0]
@@ -378,7 +379,7 @@ func TestAWSEstimation(t *testing.T) {
 		})
 		t.Run("SuccessRemote", func(t *testing.T) {
 
-			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-remote", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-remote", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			require.NoError(t, err)
 			require.Len(t, plans, 1)
 			plan := plans[0]

--- a/e2e/azurerm_estimation_test.go
+++ b/e2e/azurerm_estimation_test.go
@@ -57,7 +57,7 @@ func TestAzureRMEstimation(t *testing.T) {
 		assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(64.021), "USD"), pcost)
 	})
 	t.Run("FromHCL", func(t *testing.T) {
-		plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/azurerm/stack-compute", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+		plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/azurerm/stack-compute", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
 		plan := plans[0]

--- a/e2e/gcp_estimation_test.go
+++ b/e2e/gcp_estimation_test.go
@@ -60,7 +60,7 @@ func TestGoogleEstimation(t *testing.T) {
 		assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(39.7258116), "USD"), pcost)
 	})
 	t.Run("FromHCL", func(t *testing.T) {
-		plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/google/stack-compute", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+		plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/google/stack-compute", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
 		plan := plans[0]

--- a/e2e/invalid_estimation_test.go
+++ b/e2e/invalid_estimation_test.go
@@ -51,12 +51,12 @@ func TestVMWareEstimation(t *testing.T) {
 
 	t.Run("HCL", func(t *testing.T) {
 		t.Run("UnsupportedProvider", func(t *testing.T) {
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-vmware", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-vmware", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			assert.Nil(t, plan)
 			assert.Error(t, err, terraform.ErrNoKnownProvider)
 		})
 		t.Run("EmptyTerraform", func(t *testing.T) {
-			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-empty", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plan, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/invalid/stack-empty", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			assert.Nil(t, plan)
 			assert.Error(t, err, terraform.ErrNoQueries)
 		})

--- a/estimation.go
+++ b/estimation.go
@@ -2,6 +2,7 @@ package terracost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -10,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/afero"
 
@@ -96,6 +98,8 @@ func EstimateHCL(ctx context.Context, be backend.Backend, afs afero.Fs, stackPat
 		afs = afero.NewOsFs()
 	}
 
+	spew.Dump("stackPath", stackPath)
+	spew.Dump("relModulePath", relModulePath)
 	if !ftg {
 		var hasTG bool
 		// We first check if the main main modulePath has a Terragrunt file to know what we have to run
@@ -177,7 +181,8 @@ func EstimateHCL(ctx context.Context, be backend.Backend, afs afero.Fs, stackPat
 	// config has any of the functions like 'get_repo_root' it would fail if it's not
 	// a git repository
 	_, err = git.PlainInit(tmpdir, false)
-	if err != nil {
+	if err != nil && !errors.Is(git.ErrRepositoryAlreadyExists, err) {
+		//if err != nil {
 		return nil, fmt.Errorf("failed to initialize git repo %q: %w", tmpdir, err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/machinebox/progress v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/shopspring/decimal v1.3.1
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.9.3
 	github.com/stretchr/testify v1.7.2
 	github.com/zclconf/go-cty v1.12.1
@@ -135,7 +136,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d // indirect
 	github.com/sourcegraph/jsonrpc2 v0.1.0 // indirect
 	github.com/terraform-linters/tflint v0.44.1 // indirect

--- a/terraform/hcl_test.go
+++ b/terraform/hcl_test.go
@@ -70,6 +70,7 @@ func TestExtractQueriesFromHCL(t *testing.T) {
 					assert.Equal(t, "front", res.Name)
 					assert.Equal(t, map[string]interface{}{
 						"instances": []interface{}{"module.ec2.aws_instance.front[0]"},
+						"count":     float64(1),
 						"listener": []interface{}{
 							map[string]interface{}{
 								"instance_port":     float64(80),

--- a/testdata/aws/stack-aws/module-ec2/front.tf
+++ b/testdata/aws/stack-aws/module-ec2/front.tf
@@ -1,21 +1,22 @@
 resource "aws_instance" "front" {
   ami = data.aws_ami.debian.id
 
-  count = var.instance_count
+  count         = var.instance_count
   instance_type = var.instance_type
 
   root_block_device {
-    volume_size = var.disk_size
-    volume_type = var.disk_type
+    volume_size           = var.disk_size
+    volume_type           = var.disk_type
     delete_on_termination = true
   }
 }
 
 resource "aws_elb" "front" {
+  count = aws_instance.front.count
   listener {
-    lb_port = 80
-    lb_protocol = "tcp"
-    instance_port = 80
+    lb_port           = 80
+    lb_protocol       = "tcp"
+    instance_port     = 80
     instance_protocol = "tcp"
   }
 
@@ -23,7 +24,7 @@ resource "aws_elb" "front" {
 }
 
 module "ebs" {
-  source = "./module-ebs"
+  source            = "./module-ebs"
   availability_zone = aws_instance.front[0].availability_zone
 }
 


### PR DESCRIPTION
This PR does multiple things:
* Adds the ability to follow HCL refernces to estimate (closes #77 )
* Fixes an issue if the variables passed do not match the type defined on the HCL (weak typing)
* Adds the ability to estimate `for_each` resources