### PR TITLE
terraform: Load HCL functions into the eval context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Now HCL functions are loaded so no more errors related to functions missing
+  ([Issue #126](https://github.com/cycloidio/terracost/issue/126))
+
 ## [0.5.2] _2024-11-05_
 
 ### Added

--- a/e2e/aws_estimation_test.go
+++ b/e2e/aws_estimation_test.go
@@ -391,7 +391,7 @@ func TestAWSEstimation(t *testing.T) {
 			assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(86.474), "USD"), pcost)
 		})
 		t.Run("SuccessTerragrunt", func(t *testing.T) {
-			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/terragrunt/", "../testdata/aws/terragrunt/non-prod/us-east-1/qa/webserver-cluster/", noForceTerragrunt, noParallelismTerragrunt, usage.Default)
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/terragrunt/", "../testdata/aws/terragrunt/non-prod/us-east-1/qa/webserver-cluster/", noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
 			require.NoError(t, err)
 			require.Len(t, plans, 2)
 
@@ -409,6 +409,11 @@ func TestAWSEstimation(t *testing.T) {
 					assertCostEqual(t, cost.NewMonthly(decimal.NewFromFloat(18.25), "USD"), pcost)
 				}
 			}
+		})
+		t.Run("SuccessFunctions", func(t *testing.T) {
+			plans, err := costestimation.EstimateHCL(ctx, backend, nil, "../testdata/aws/stack-functions/", noModulePath, noForceTerragrunt, noParallelismTerragrunt, usage.Default, noDebug)
+			require.NoError(t, err)
+			require.Len(t, plans, 1)
 		})
 	})
 }

--- a/terraform/hcl.go
+++ b/terraform/hcl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/getmodules"
+	"github.com/hashicorp/terraform/lang"
 	"github.com/hashicorp/terraform/registry"
 	"github.com/hashicorp/terraform/registry/regsrc"
 	"github.com/spf13/afero"
@@ -405,12 +406,14 @@ func getEvalCtx(mod *configs.Module, vars map[string]cty.Value, inputs map[strin
 		}
 	}
 
+	scope := lang.Scope{}
 	// Initialize the evaluation context that will be used by the Terraform parser to fill in values
 	// of variables. E.g. the `var` element contains variable values accessible from HCL using `var.*`.
 	evalCtx := &hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"var": cty.ObjectVal(vars),
 		},
+		Functions: scope.Functions(),
 	}
 
 	// Set values of locals.

--- a/testdata/aws/stack-functions/main.tf
+++ b/testdata/aws/stack-functions/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "ec2" {
+  source = "./module-ec2"
+}

--- a/testdata/aws/stack-functions/module-ec2/main.tf
+++ b/testdata/aws/stack-functions/module-ec2/main.tf
@@ -1,0 +1,32 @@
+variable "create_bucket" {
+  description = "Controls if S3 bucket should be created"
+  type        = bool
+  default     = true
+}
+
+variable "metric_configuration" {
+  description = "Map containing bucket metric configuration."
+  type        = any
+  default     = []
+}
+
+
+locals {
+  create_bucket        = var.create_bucket
+  metric_configuration = try(jsondecode(var.metric_configuration), var.metric_configuration)
+}
+
+
+resource "aws_s3_bucket" "this" {
+  count  = local.create_bucket ? 1 : 0
+  bucket = "foobar"
+}
+
+resource "aws_s3_bucket_metric" "this" {
+  for_each = { for k, v in local.metric_configuration : k => v if local.create_bucket }
+
+  name   = each.value.name
+  bucket = aws_s3_bucket.this[0].id
+}
+
+


### PR DESCRIPTION
So then they can be used and evaluated

Closes #126 