### PR TITLE
Fix multiple plan parsing bugs affecting resource estimation

### DIFF
--- a/aws/terraform/eks_node_group.go
+++ b/aws/terraform/eks_node_group.go
@@ -85,7 +85,17 @@ func (p *Provider) newEKSNodeGroup(rss map[string]terraform.Resource, vals eksNo
 			}
 		}
 
-		lt, err := decodeLaunchTemplateValues(rss[ltref].Values)
+		ltRes, ok := rss[ltref]
+		if !ok || ltRes.Values == nil {
+			// LT not found (e.g. ID/Name unknown at plan time), fall back to node group instance types
+			if len(vals.InstanceTypes) > 0 {
+				inst.instanceType = vals.InstanceTypes[0]
+			} else {
+				inst.instanceType = defaultEKSInstanceType
+			}
+			return inst
+		}
+		lt, err := decodeLaunchTemplateValues(ltRes.Values)
 		if err != nil {
 			return inst
 		}

--- a/aws/terraform_provider.go
+++ b/aws/terraform_provider.go
@@ -35,7 +35,7 @@ var TerraformProviderInitializer = terraform.ProviderInitializer{
 
 		switch value := r.(type) {
 		case string:
-			if regCode == "" {
+			if value == "" {
 				log.Logger.Info(fmt.Sprintf("AWS terraform provider region not set, defaulting to %s", DefaultRegion))
 				return awstf.NewProvider(ProviderName, DefaultRegion)
 			}

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -157,7 +157,7 @@ func (p *Plan) extractModuleConfiguration(prefix string, module *ConfigurationMo
 		if child.Module != nil {
 			nextPrefix := k
 			if prefix != "" {
-				nextPrefix = fmt.Sprintf("%s.%s", prefix, k)
+				nextPrefix = fmt.Sprintf("%s.module.%s", prefix, k)
 			}
 			err := p.extractModuleConfiguration(nextPrefix, child.Module, providers, resourceProviders)
 			if err != nil {
@@ -168,7 +168,7 @@ func (p *Plan) extractModuleConfiguration(prefix string, module *ConfigurationMo
 	return nil
 }
 
-var reResAddrClean = regexp.MustCompile(`\[\d*\]`)
+var reResAddrClean = regexp.MustCompile(`\[[^\]]*\]`)
 
 // cleanResourceAddresss will remove all unnecessary parts of it so it can be matched:
 // * Remove all the [*] that it may have
@@ -186,6 +186,9 @@ func (p *Plan) extractModuleQueries(module *Module, resourceProviders map[string
 		pwrv, ok := resourceProviders[cleanResourceAddresss(tfres.Address)]
 		if !ok || tfres.Mode != "managed" {
 			continue
+		}
+		if tfres.Values == nil {
+			tfres.Values = make(map[string]interface{})
 		}
 		for k, v := range pwrv.Values {
 			if v == nil {


### PR DESCRIPTION
## Summary

Fixes several bugs in Terraform plan parsing that caused incorrect or missing cost estimates:
- **Nil map panic on null resource values**: Resources like `aws_iam_role_policy_attachment` can have `null` values in `planned_values` when all attributes are unknown at plan time (e.g. policy ARN depends on a resource being created in the same plan). Assigning to the nil map caused a panic. Fixed by initializing the map before writing.
- **AWS provider region ignored**: The region from provider config (e.g. `eu-north-1`) was never used - the code checked an uninitialized `regCode` variable instead of the actual `value` from the plan, so it always defaulted to `us-east-1`. This caused incorrect pricing for non-us-east-1 regions.
- **`for_each` resources not estimated**: The address cleaning regex `\[\d*\]` only stripped numeric indices (`[0]`, `[1]`), but `for_each` resources use string indices (`["db"]`, `["web"]`). These resources were silently skipped. Fixed the regex to strip all index types.
- **Nested module resources not estimated**: When building resource addresses for nested modules, the code produced `module.eks.eks_managed_node_group.resource` instead of the correct `module.eks.module.eks_managed_node_group.resource`. The missing `module.` segment caused lookup failures.
- **EKS node group $0 with launch template**: When a node group references a launch template being created in the same plan, the LT's ID/Name are unknown, so the lookup fails. Previously this returned early with no instance type. Now falls back to `instance_types` from the node group resource itself.
